### PR TITLE
feat: snapshot manager tls suport

### DIFF
--- a/charts/daytona-region/Chart.yaml
+++ b/charts/daytona-region/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: daytona-region
 description: A Helm chart for Daytona custom region
 type: application
-version: 0.0.8
+version: 0.0.9
 appVersion: "v0.134.1-rc.1"
 keywords:
   - ai

--- a/charts/daytona-region/templates/NOTES.txt
+++ b/charts/daytona-region/templates/NOTES.txt
@@ -1,0 +1,73 @@
+{{- $namespace := include "daytona.namespace" . -}}
+{{- $fullname := include "daytona.fullname" . -}}
+
+Daytona Region has been installed successfully!
+
+Region Name: {{ .Values.regionName }}
+Namespace:   {{ $namespace }}
+
+{{- if .Values.registration.enabled }}
+
+==========================================================================
+REGION REGISTRATION
+==========================================================================
+
+A pre-install hook has registered this region with the Daytona API.
+The region configuration is stored in the secret: {{ $fullname }}-region-config
+
+To view the region configuration:
+  kubectl get secret {{ $fullname }}-region-config -n {{ $namespace }} -o yaml
+
+{{- end }}
+
+==========================================================================
+SERVICES
+==========================================================================
+
+{{- if .Values.services.proxy }}
+Proxy Service:
+  URL: {{ include "daytona.proxyUrl" . }}
+  {{- if .Values.services.proxy.ingress.enabled }}
+  Ingress: Enabled ({{ .Values.services.proxy.ingress.className }})
+  {{- end }}
+{{- end }}
+
+{{- if .Values.services.snapshotManager.enabled }}
+Snapshot Manager:
+  {{- if .Values.snapshotManagerUrl }}
+  URL: {{ .Values.snapshotManagerUrl }}
+  {{- else }}
+  Service: {{ $fullname }}-snapshot-manager.{{ $namespace }}.svc.cluster.local:{{ .Values.services.snapshotManager.service.port }}
+  {{- end }}
+  {{- if .Values.services.snapshotManager.ingress.enabled }}
+  Ingress: Enabled ({{ .Values.services.snapshotManager.ingress.className }})
+  {{- end }}
+{{- end }}
+
+{{- if and .Values.services.snapshotManager.enabled .Values.services.snapshotManager.http.tls.selfSigned (not .Values.services.snapshotManager.http.tls.secretName) }}
+
+==========================================================================
+SNAPSHOT MANAGER TLS CERTIFICATE
+==========================================================================
+
+A self-signed TLS certificate has been generated for the Snapshot Manager.
+Secret Name: {{ $fullname }}-snapshot-manager-tls
+Hostname: {{ .Values.services.snapshotManager.http.tls.hostname }}
+Validity: 10 years
+
+To retrieve the CA certificate (to add to your trust store):
+
+  kubectl get secret {{ $fullname }}-snapshot-manager-tls -n {{ $namespace }} -o jsonpath='{.data.ca\.crt}' | base64 -d
+
+To save the CA certificate to a file:
+
+  kubectl get secret {{ $fullname }}-snapshot-manager-tls -n {{ $namespace }} -o jsonpath='{.data.ca\.crt}' | base64 -d > daytona-snapshot-manager-ca.crt
+
+To view certificate details:
+
+  kubectl get secret {{ $fullname }}-snapshot-manager-tls -n {{ $namespace }} -o jsonpath='{.data.tls\.crt}' | base64 -d | openssl x509 -noout -text
+
+To trust this certificate in your system, add the CA certificate to your
+trust store. Instructions vary by operating system.
+
+{{- end }}

--- a/charts/daytona-region/templates/_helpers.tpl
+++ b/charts/daytona-region/templates/_helpers.tpl
@@ -211,3 +211,13 @@ Usage:
 {{- define "daytona.snapshotManagerUrl" -}}
 {{- .Values.snapshotManagerUrl | default "http://snapshots.daytona.local:5000" -}}
 {{- end -}}
+
+{{/*
+Check if TLS is enabled for snapshot manager.
+Returns true if either selfSigned is enabled or secretName is provided.
+Usage:
+{{ include "daytona.snapshotManager.tlsEnabled" . }}
+*/}}
+{{- define "daytona.snapshotManager.tlsEnabled" -}}
+{{- or .Values.services.snapshotManager.http.tls.selfSigned .Values.services.snapshotManager.http.tls.secretName -}}
+{{- end -}}

--- a/charts/daytona-region/templates/snapshot-manager-deployment.yaml
+++ b/charts/daytona-region/templates/snapshot-manager-deployment.yaml
@@ -123,14 +123,30 @@ spec:
               value: {{ .Values.services.snapshotManager.cache.driver | quote }}
             {{- end }}
             {{- end }}
+            # TLS configuration
+            {{- if include "daytona.snapshotManager.tlsEnabled" . }}
+            - name: SNAPSHOT_MANAGER_HTTP_TLS_CERTIFICATE
+              value: "/etc/snapshot-manager/tls/tls.crt"
+            - name: SNAPSHOT_MANAGER_HTTP_TLS_KEY
+              value: "/etc/snapshot-manager/tls/tls.key"
+            {{- end }}
             {{- with .Values.services.snapshotManager.extraEnv }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
+          {{- if include "daytona.snapshotManager.tlsEnabled" . }}
+          volumeMounts:
+            - name: tls-certs
+              mountPath: /etc/snapshot-manager/tls
+              readOnly: true
+          {{- end }}
           {{- if .Values.services.snapshotManager.livenessProbe.enabled }}
           livenessProbe:
             httpGet:
               path: {{ .Values.services.snapshotManager.livenessProbe.path | default "/v2/" }}
               port: http
+              {{- if include "daytona.snapshotManager.tlsEnabled" . }}
+              scheme: HTTPS
+              {{- end }}
             initialDelaySeconds: {{ .Values.services.snapshotManager.livenessProbe.initialDelaySeconds | default 10 }}
             periodSeconds: {{ .Values.services.snapshotManager.livenessProbe.periodSeconds | default 30 }}
             timeoutSeconds: {{ .Values.services.snapshotManager.livenessProbe.timeoutSeconds | default 5 }}
@@ -141,6 +157,9 @@ spec:
             httpGet:
               path: {{ .Values.services.snapshotManager.readinessProbe.path | default "/v2/" }}
               port: http
+              {{- if include "daytona.snapshotManager.tlsEnabled" . }}
+              scheme: HTTPS
+              {{- end }}
             initialDelaySeconds: {{ .Values.services.snapshotManager.readinessProbe.initialDelaySeconds | default 5 }}
             periodSeconds: {{ .Values.services.snapshotManager.readinessProbe.periodSeconds | default 10 }}
             timeoutSeconds: {{ .Values.services.snapshotManager.readinessProbe.timeoutSeconds | default 5 }}
@@ -148,6 +167,12 @@ spec:
           {{- end }}
           resources:
             {{- toYaml .Values.services.snapshotManager.resources | nindent 12 }}
+      {{- if include "daytona.snapshotManager.tlsEnabled" . }}
+      volumes:
+        - name: tls-certs
+          secret:
+            secretName: {{ if .Values.services.snapshotManager.http.tls.secretName }}{{ .Values.services.snapshotManager.http.tls.secretName }}{{ else }}{{ include "daytona.fullname" . }}-snapshot-manager-tls{{ end }}
+      {{- end }}
       {{- with .Values.services.snapshotManager.nodeSelector | default .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/daytona-region/templates/snapshot-manager-tls-hook.yaml
+++ b/charts/daytona-region/templates/snapshot-manager-tls-hook.yaml
@@ -1,0 +1,132 @@
+{{- if and .Values.services.snapshotManager.enabled .Values.services.snapshotManager.http.tls.selfSigned (not .Values.services.snapshotManager.http.tls.secretName) -}}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "daytona.fullname" . }}-snapshot-manager-tls
+  namespace: {{ include "daytona.namespace" . }}
+  labels:
+    {{- include "daytona.labels" . | nindent 4 }}
+    app.kubernetes.io/component: snapshot-manager-tls
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  ttlSecondsAfterFinished: 300
+  backoffLimit: 3
+  template:
+    metadata:
+      labels:
+        {{- include "daytona.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: snapshot-manager-tls
+    spec:
+      serviceAccountName: {{ include "daytona.fullname" . }}-snapshot-manager-tls
+      restartPolicy: OnFailure
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: generate-tls
+          image: {{ .Values.registration.image.repository }}:{{ .Values.registration.image.tag }}
+          imagePullPolicy: {{ .Values.registration.image.pullPolicy }}
+          command:
+            - /bin/sh
+            - -c
+            - |
+              set -e
+
+              SECRET_NAME="{{ include "daytona.fullname" . }}-snapshot-manager-tls"
+              NAMESPACE="{{ include "daytona.namespace" . }}"
+              HOSTNAME="{{ required "services.snapshotManager.http.tls.hostname is required when selfSigned is enabled" .Values.services.snapshotManager.http.tls.hostname }}"
+
+              # Check if TLS secret already exists
+              if kubectl get secret "${SECRET_NAME}" -n "${NAMESPACE}" >/dev/null 2>&1; then
+                echo "TLS secret '${SECRET_NAME}' already exists. Skipping certificate generation."
+                exit 0
+              fi
+
+              echo "Generating self-signed TLS certificates for ${HOSTNAME}..."
+
+              # Create working directory
+              WORK_DIR=$(mktemp -d)
+              cd "${WORK_DIR}"
+
+              # Generate CA private key
+              echo "Generating CA private key..."
+              openssl genrsa -out ca.key 4096
+
+              # Generate CA certificate (10 years validity)
+              echo "Generating CA certificate..."
+              openssl req -new -x509 -days 3650 -key ca.key -out ca.crt \
+                -subj "/CN=Daytona Snapshot Manager CA/O=Daytona/OU=Snapshot Manager"
+
+              # Generate server private key
+              echo "Generating server private key..."
+              openssl genrsa -out tls.key 4096
+
+              # Generate certificate signing request
+              echo "Generating certificate signing request..."
+              openssl req -new -key tls.key -out server.csr \
+                -subj "/CN=${HOSTNAME}/O=Daytona/OU=Snapshot Manager"
+
+              # Create OpenSSL config for SAN
+              cat > openssl.cnf <<EOF
+              [req]
+              req_extensions = v3_req
+              distinguished_name = req_distinguished_name
+
+              [req_distinguished_name]
+
+              [v3_req]
+              basicConstraints = CA:FALSE
+              keyUsage = nonRepudiation, digitalSignature, keyEncipherment
+              subjectAltName = @alt_names
+
+              [alt_names]
+              DNS.1 = ${HOSTNAME}
+              EOF
+
+              # Generate server certificate signed by CA (10 years validity)
+              echo "Generating server certificate..."
+              openssl x509 -req -in server.csr -CA ca.crt -CAkey ca.key \
+                -CAcreateserial -out tls.crt -days 3650 \
+                -extensions v3_req -extfile openssl.cnf
+
+              # Verify the certificate
+              echo "Verifying certificate..."
+              openssl verify -CAfile ca.crt tls.crt
+
+              # Create Kubernetes secret
+              echo "Creating TLS secret..."
+              kubectl create secret generic "${SECRET_NAME}" \
+                --from-file=tls.crt=tls.crt \
+                --from-file=tls.key=tls.key \
+                --from-file=ca.crt=ca.crt \
+                -n "${NAMESPACE}"
+
+              # Label the secret
+              kubectl label secret "${SECRET_NAME}" \
+                -n "${NAMESPACE}" \
+                {{- include "daytona.labels" . | nindent 16 }} \
+                app.kubernetes.io/component=snapshot-manager
+
+              echo "TLS certificate generation complete!"
+              echo "Certificate details:"
+              openssl x509 -in tls.crt -noout -text | grep -A2 "Validity"
+              openssl x509 -in tls.crt -noout -text | grep -A1 "Subject Alternative Name"
+
+              # Cleanup
+              cd /
+              rm -rf "${WORK_DIR}"
+          resources:
+            {{- toYaml .Values.registration.resources | nindent 12 }}
+      {{- with .Values.registration.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.registration.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/charts/daytona-region/templates/snapshot-manager-tls-rbac.yaml
+++ b/charts/daytona-region/templates/snapshot-manager-tls-rbac.yaml
@@ -1,0 +1,52 @@
+{{- if and .Values.services.snapshotManager.enabled .Values.services.snapshotManager.http.tls.selfSigned (not .Values.services.snapshotManager.http.tls.secretName) -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "daytona.fullname" . }}-snapshot-manager-tls
+  namespace: {{ include "daytona.namespace" . }}
+  labels:
+    {{- include "daytona.labels" . | nindent 4 }}
+    app.kubernetes.io/component: snapshot-manager-tls
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-10"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "daytona.fullname" . }}-snapshot-manager-tls
+  namespace: {{ include "daytona.namespace" . }}
+  labels:
+    {{- include "daytona.labels" . | nindent 4 }}
+    app.kubernetes.io/component: snapshot-manager-tls
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-10"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["create", "update", "patch", "get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "daytona.fullname" . }}-snapshot-manager-tls
+  namespace: {{ include "daytona.namespace" . }}
+  labels:
+    {{- include "daytona.labels" . | nindent 4 }}
+    app.kubernetes.io/component: snapshot-manager-tls
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-10"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "daytona.fullname" . }}-snapshot-manager-tls
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "daytona.fullname" . }}-snapshot-manager-tls
+    namespace: {{ include "daytona.namespace" . }}
+{{- end }}

--- a/charts/daytona-region/values.yaml
+++ b/charts/daytona-region/values.yaml
@@ -207,6 +207,26 @@ services:
     http:
       # Port the service listens on
       port: 5000
+      # TLS configuration
+      tls:
+        # Existing secret name containing TLS certificate and key
+        # The secret must contain keys: tls.crt and tls.key
+        # If set, the certificate and key will be mounted in the pod and
+        # environment variables SNAPSHOT_MANAGER_HTTP_TLS_CERTIFICATE and
+        # SNAPSHOT_MANAGER_HTTP_TLS_KEY will be set to their paths
+        # IMPORTANT: This takes precedence over selfSigned. If secretName is set,
+        # selfSigned will be ignored.
+        secretName: ""
+        # Enable self-signed certificate generation
+        # When enabled and secretName is empty, a pre-install/pre-upgrade hook will
+        # generate a self-signed CA and certificate with 10 years validity.
+        # The certificate will be preserved across upgrades.
+        # Works with ArgoCD and GitOps workflows.
+        # NOTE: This is ignored if secretName is set.
+        selfSigned: false
+        # Hostname for the TLS certificate (required when selfSigned is enabled)
+        # Supports wildcards (e.g., "*.example.com" or "snapshots.daytona.example.com")
+        hostname: ""
     # Additional environment variables
     extraEnv: []
     # Liveness probe configuration
@@ -264,7 +284,7 @@ registration:
   # Image for the registration job (needs curl and kubectl)
   image:
     repository: daytonaio/kubectl
-    tag: "1.34.2-r1"
+    tag: "1.34.2-r2"
     pullPolicy: IfNotPresent
   # Resource limits for the registration job
   resources:


### PR DESCRIPTION
# Add TLS Support for Snapshot Manager

## Summary

Adds TLS support for the snapshot-manager service with automated self-signed certificate generation via Helm hooks and support for user-provided certificates.

## Key Features

### 1. TLS Configuration (`values.yaml`)

```yaml
services:
  snapshotManager:
    http:
      tls:
        secretName: ""      # Use existing secret (takes precedence)
        selfSigned: false   # Enable auto-generated self-signed cert
        hostname: ""        # Required for selfSigned (supports wildcards)
```

### 2. Self-Signed Certificate Generation

- Pre-install/pre-upgrade hook generates CA + server cert (10-year validity)
- Certificates preserved across upgrades (only generates if missing)
- Supports wildcard hostnames (`*.example.com`)

### 3. Deployment Updates

- Mounts TLS secret at `/etc/snapshot-manager/tls`
- Sets `SNAPSHOT_MANAGER_HTTP_TLS_CERTIFICATE` and `SNAPSHOT_MANAGER_HTTP_TLS_KEY` env vars
- Updates health checks to use `scheme: HTTPS` when TLS enabled

### 4. Helper Template

- Added `daytona.snapshotManager.tlsEnabled` helper to centralize TLS check logic

### 5. NOTES.txt

- Instructions to retrieve and view CA certificate after installation

## Files Changed

**Modified:**
- `values.yaml` - TLS configuration section
- `snapshot-manager-deployment.yaml` - TLS mounting + HTTPS probes
- `_helpers.tpl` - Helper template
- `NOTES.txt` - CA certificate instructions

**Added:**
- `snapshot-manager-tls-hook.yaml` - Certificate generation job
- `snapshot-manager-tls-rbac.yaml` - RBAC for hook

## Usage

**Self-signed**

```yaml
services:
  snapshotManager:
    http:
      tls:
        selfSigned: true
        hostname: "*.elb.us-east-1.amazonaws.com"
```

**User-provided**

```yaml
services:
  snapshotManager:
    http:
      tls:
        secretName: "my-tls-secret"
```

## Breaking Changes

None. TLS is opt-in.
