### PR TITLE
feat: make TLS secret name configurable via values

### DIFF
--- a/charts/daytona-region/templates/proxy-ingress.yaml
+++ b/charts/daytona-region/templates/proxy-ingress.yaml
@@ -69,11 +69,12 @@ spec:
     {{- end }}
   {{- if .Values.services.proxy.ingress.tls }}
   tls:
+    {{- $tlsSecretName := .Values.services.proxy.ingress.tlsSecretName | default (printf "%s-tls" $proxyHostname) }}
     # Use wildcard certificate (covers proxy hostname and all subdomains)
     - hosts:
         - {{ $proxyHostname | quote }}
         - {{ $wildcardProxyHostname | quote }}
-      secretName: {{ printf "%s-tls" $proxyHostname }}
+      secretName: {{ $tlsSecretName }}
     {{- if .Values.services.proxy.ingress.extraTls }}
     {{- toYaml .Values.services.proxy.ingress.extraTls | nindent 4 }}
     {{- end }}

--- a/charts/daytona-region/templates/proxy-tls-secrets.yaml
+++ b/charts/daytona-region/templates/proxy-tls-secrets.yaml
@@ -19,7 +19,7 @@ data:
 {{- if and .Values.services.proxy.ingress.tls .Values.services.proxy.ingress.selfSigned }}
 {{- $proxyHostname := include "daytona.proxyUrl.hostname" . }}
 {{- $wildcardHostname := printf "*.%s" $proxyHostname }}
-{{- $secretName := printf "%s-tls" $proxyHostname }}
+{{- $secretName := .Values.services.proxy.ingress.tlsSecretName | default (printf "%s-tls" $proxyHostname) }}
 {{- $ca := genCA "daytona-proxy-ca" 365 }}
 {{- $cert := genSignedCert $proxyHostname nil (list $proxyHostname $wildcardHostname) 365 $ca }}
 apiVersion: v1

--- a/charts/daytona-region/templates/snapshot-manager-ingress.yaml
+++ b/charts/daytona-region/templates/snapshot-manager-ingress.yaml
@@ -53,9 +53,10 @@ spec:
     {{- end }}
   {{- if .Values.services.snapshotManager.ingress.tls }}
   tls:
+    {{- $tlsSecretName := .Values.services.snapshotManager.ingress.tlsSecretName | default (printf "%s-tls" $templatedHostname) }}
     - hosts:
         - {{ $templatedHostname | quote }}
-      secretName: {{ printf "%s-tls" $templatedHostname }}
+      secretName: {{ $tlsSecretName }}
     {{- if .Values.services.snapshotManager.ingress.extraTls }}
     {{- toYaml .Values.services.snapshotManager.ingress.extraTls | nindent 4 }}
     {{- end }}

--- a/charts/daytona-region/values.yaml
+++ b/charts/daytona-region/values.yaml
@@ -68,6 +68,10 @@ services:
       tls: true
       # Enable self-signed certificates
       selfSigned: false
+      # TLS secret name override
+      # If not set, defaults to "{{proxy-hostname}}-tls" (e.g., "proxy.daytona.example.com-tls")
+      # Use this when you have a pre-existing TLS secret with a different naming convention
+      tlsSecretName: ""
       # Custom TLS certificates as secrets
       # NOTE: 'key' and 'certificate' are expected in PEM format
       # NOTE: 'name' should match the secretName used in ingress TLS configuration
@@ -174,6 +178,10 @@ services:
       extraTls: []
       extraRules: []
       tls: true
+      # TLS secret name override
+      # If not set, defaults to "{{hostname}}-tls" (e.g., "snapshots.daytona.example.com-tls")
+      # Use this when you have a pre-existing TLS secret with a different naming convention
+      tlsSecretName: ""
     # Storage configuration
     storage:
       # S3 storage configuration

--- a/charts/daytona/templates/api-ingress.yaml
+++ b/charts/daytona/templates/api-ingress.yaml
@@ -59,10 +59,11 @@ spec:
     {{- $baseDomain := .Values.baseDomain -}}
     {{- $templatedBaseDomain := tpl $baseDomain $ -}}
     {{- $wildcardBaseDomain := printf "*.%s" $templatedBaseDomain }}
+    {{- $tlsSecretName := .Values.services.api.ingress.tlsSecretName | default (printf "%s-tls" $templatedBaseDomain) }}
     - hosts:
         - {{ $templatedHostname | quote }}
         - {{ $wildcardBaseDomain | quote }}
-      secretName: {{ printf "%s-tls" $templatedBaseDomain }}
+      secretName: {{ $tlsSecretName }}
     {{- end }}
     {{- if .Values.services.api.ingress.extraTls }}
     {{- toYaml .Values.services.api.ingress.extraTls | nindent 4 }}

--- a/charts/daytona/templates/api-tls-secrets.yaml
+++ b/charts/daytona/templates/api-tls-secrets.yaml
@@ -18,9 +18,9 @@ data:
 {{- end }}
 {{- if and .Values.services.api.ingress.tls .Values.services.api.ingress.selfSigned }}
 {{- $hostname := .Values.services.api.ingress.hostname | default .Values.baseDomain }}
-{{- $secretName := printf "%s-tls" (tpl $hostname $) }}
-{{- $ca := genCA "daytona-api-ca" 365 }}
 {{- $templatedHostname := tpl $hostname $ }}
+{{- $secretName := .Values.services.api.ingress.tlsSecretName | default (printf "%s-tls" $templatedHostname) }}
+{{- $ca := genCA "daytona-api-ca" 365 }}
 {{- $cert := genSignedCert $templatedHostname nil (list $templatedHostname) 365 $ca }}
 apiVersion: v1
 kind: Secret

--- a/charts/daytona/templates/dex-ingress.yaml
+++ b/charts/daytona/templates/dex-ingress.yaml
@@ -56,9 +56,10 @@ spec:
   {{- if .Values.dex.ingress.tls }}
   tls:
     {{- if $hostname }}
+    {{- $tlsSecretName := .Values.dex.ingress.tlsSecretName | default (printf "%s-tls" $templatedHostname) }}
     - hosts:
         - {{ $templatedHostname | quote }}
-      secretName: {{ printf "%s-tls" $templatedHostname }}
+      secretName: {{ $tlsSecretName }}
     {{- end }}
     {{- if .Values.dex.ingress.extraTls }}
     {{- toYaml .Values.dex.ingress.extraTls | nindent 4 }}

--- a/charts/daytona/templates/proxy-ingress.yaml
+++ b/charts/daytona/templates/proxy-ingress.yaml
@@ -71,10 +71,11 @@ spec:
     {{- end }}
   {{- if .Values.services.proxy.ingress.tls }}
   tls:
+    {{- $tlsSecretName := .Values.services.proxy.ingress.tlsSecretName | default (printf "proxy.%s-tls" $templatedBaseDomain) }}
     # Use wildcard certificate (covers all subdomains including proxy subdomain)
     - hosts:
         - {{ $wildcardBaseDomain | quote }}
-      secretName: {{ printf "proxy.%s-tls" $templatedBaseDomain }}
+      secretName: {{ $tlsSecretName }}
     {{- if .Values.services.proxy.ingress.extraTls }}
     {{- toYaml .Values.services.proxy.ingress.extraTls | nindent 4 }}
     {{- end }}

--- a/charts/daytona/templates/proxy-tls-secrets.yaml
+++ b/charts/daytona/templates/proxy-tls-secrets.yaml
@@ -20,7 +20,7 @@ data:
 {{- $hostname := .Values.services.proxy.ingress.hostname | default (printf "proxy.%s" .Values.baseDomain) }}
 {{- $templatedHostname := tpl $hostname $ }}
 {{- $wildcardHostname := printf "*.%s" $templatedHostname }}
-{{- $secretName := printf "%s-tls" $templatedHostname }}
+{{- $secretName := .Values.services.proxy.ingress.tlsSecretName | default (printf "%s-tls" $templatedHostname) }}
 {{- $ca := genCA "daytona-proxy-ca" 365 }}
 {{- $cert := genSignedCert $templatedHostname nil (list $templatedHostname $wildcardHostname) 365 $ca }}
 apiVersion: v1

--- a/charts/daytona/values.yaml
+++ b/charts/daytona/values.yaml
@@ -48,6 +48,10 @@ services:
       tls: true
       # Enable self-signed certificates
       selfSigned: false
+      # TLS secret name override
+      # If not set, defaults to "{{baseDomain}}-tls" (e.g., "daytona.example.com-tls")
+      # Use this when you have a pre-existing TLS secret with a different naming convention
+      tlsSecretName: ""
       # Custom TLS certificates as secrets
       # NOTE: 'key' and 'certificate' are expected in PEM format
       # NOTE: 'name' should match the secretName used in ingress TLS configuration
@@ -236,6 +240,10 @@ services:
       tls: true
       # Enable self-signed certificates
       selfSigned: false
+      # TLS secret name override
+      # If not set, defaults to "proxy.{{baseDomain}}-tls" (e.g., "proxy.daytona.example.com-tls")
+      # Use this when you have a pre-existing TLS secret with a different naming convention
+      tlsSecretName: ""
       # Custom TLS certificates as secrets
       # NOTE: 'key' and 'certificate' are expected in PEM format
       # NOTE: 'name' should match the secretName used in ingress TLS configuration
@@ -593,6 +601,10 @@ dex:
     tls: true
     # Enable self-signed certificates
     selfSigned: false
+    # TLS secret name override
+    # If not set, defaults to "{{dex-hostname}}-tls" (e.g., "dex.daytona.example.com-tls")
+    # Use this when you have a pre-existing TLS secret with a different naming convention
+    tlsSecretName: ""
     # Custom TLS certificates as secrets
     # NOTE: 'key' and 'certificate' are expected in PEM format
     # NOTE: 'name' should match the secretName used in ingress TLS configuration


### PR DESCRIPTION
Add tlsSecretName option to ingress configurations in both daytona and daytona-region charts. This allows users to specify a pre-existing TLS secret instead of relying on the auto-generated {hostname}-tls pattern, which is needed for customer environments with restrictive naming policies.