### PR TITLE
fix: modify documentation language to replace the incorrect api endpoint

### DIFF
--- a/charts/daytona-region/README.md
+++ b/charts/daytona-region/README.md
@@ -39,7 +39,7 @@ regionName: "my-custom-region"
 proxyUrl: "https://proxy.mycompany.daytona.io"
 
 # Daytona API credentials (obtain from your Daytona organization)
-daytonaApiUrl: "https://api.daytona.io/api"
+daytonaApiUrl: "https://app.daytona.io/api"
 daytonaApiKey: "dtn_your_api_key_here"
 
 # Enable region registration (required for first install)

--- a/charts/daytona-region/values.yaml
+++ b/charts/daytona-region/values.yaml
@@ -23,7 +23,7 @@ proxyUrl: ""
 snapshotManagerUrl: ""
 
 # Daytona API configuration (required)
-daytonaApiUrl: ""   # e.g., "https://api.daytona.io/api"
+daytonaApiUrl: ""   # e.g., "https://app.daytona.io/api"
 daytonaApiKey: ""   # API key for authentication
 
 # Service-specific configurations


### PR DESCRIPTION
# Description

Documentation notes and suggestions in the yaml and template reference an endpoint and url that does not exist (api.daytona.io/api) which is the incorrect suggestion and will result in the helm chart not working correctly. Replaced those incorrect references with app.daytona.io/api.

A similar change to the endpoint referenced in a part of the code as the actual URL being passed, which results in errors.