### PR TITLE
fix: add --force-conflicts to dpkg docker install in runner daemonset

### DIFF
--- a/charts/daytona/templates/runner-daemonset.yaml
+++ b/charts/daytona/templates/runner-daemonset.yaml
@@ -270,8 +270,8 @@ spec:
                   wget https://download.docker.com/linux/ubuntu/dists/noble/pool/stable/amd64/docker-ce-cli_${DOCKER_VERSION}_amd64.deb
                   #wget https://download.docker.com/linux/ubuntu/dists/noble/pool/stable/amd64/docker-buildx-plugin_0.19.3-1~ubuntu.24.04~noble_amd64.deb
                   # Install with --force-depends to skip the containerd.io dependency
-                  dpkg --force-depends -i docker-ce-cli_${DOCKER_VERSION}_amd64.deb
-                  dpkg --force-depends -i docker-ce_${DOCKER_VERSION}_amd64.deb
+                  dpkg --force-depends --force-conflicts -i docker-ce-cli_${DOCKER_VERSION}_amd64.deb
+                  dpkg --force-depends --force-conflicts -i docker-ce_${DOCKER_VERSION}_amd64.deb
                   
                   mkdir -p /etc/docker
                   systemctl daemon-reload


### PR DESCRIPTION
The runner daemonset's Debian/Ubuntu docker installer uses `dpkg --force-depends` to bypass the containerd.io dependency when installing the docker-ce-cli and docker-ce .deb packages. On base images that already provide conflicting docker CLI/engine files (e.g. docker.io, containerd, or a partially-installed docker-ce from an earlier layer), dpkg still aborts with "trying to overwrite '/usr/bin/...', which is also in package ..." errors.

Adding --force-conflicts lets dpkg overwrite the conflicting files so the install completes on a wider range of node images, matching the intent of the existing --force-depends override.