### PR TITLE
fix(migration): wait for postgres before running migrations

### DIFF
--- a/charts/daytona/templates/api-migration-init-job.yaml
+++ b/charts/daytona/templates/api-migration-init-job.yaml
@@ -26,6 +26,30 @@ spec:
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       restartPolicy: Never
+      initContainers:
+        - name: wait-for-postgres
+          image: busybox:1.37
+          imagePullPolicy: IfNotPresent
+          command: ["sh", "-c"]
+          args:
+            - |
+              echo "Waiting for postgres at ${DB_HOST}:${DB_PORT}..."
+              until nc -z -w 2 "${DB_HOST}" "${DB_PORT}"; do
+                sleep 3
+              done
+              echo "postgres reachable"
+          env:
+            {{- if .Values.postgresql.enabled }}
+            - name: DB_HOST
+              value: {{ printf "%s-postgresql" .Release.Name | quote }}
+            - name: DB_PORT
+              value: "5432"
+            {{- else }}
+            - name: DB_HOST
+              value: {{ .Values.externalDatabase.host | default (.Values.services.api.env.DB_HOST | default "") | quote }}
+            - name: DB_PORT
+              value: {{ .Values.externalDatabase.port | default (.Values.services.api.env.DB_PORT | default "5432") | quote }}
+            {{- end }}
       containers:
         - name: migration
           securityContext:

--- a/charts/daytona/templates/api-migration-post-deploy-job.yaml
+++ b/charts/daytona/templates/api-migration-post-deploy-job.yaml
@@ -26,6 +26,30 @@ spec:
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       restartPolicy: Never
+      initContainers:
+        - name: wait-for-postgres
+          image: busybox:1.37
+          imagePullPolicy: IfNotPresent
+          command: ["sh", "-c"]
+          args:
+            - |
+              echo "Waiting for postgres at ${DB_HOST}:${DB_PORT}..."
+              until nc -z -w 2 "${DB_HOST}" "${DB_PORT}"; do
+                sleep 3
+              done
+              echo "postgres reachable"
+          env:
+            {{- if .Values.postgresql.enabled }}
+            - name: DB_HOST
+              value: {{ printf "%s-postgresql" .Release.Name | quote }}
+            - name: DB_PORT
+              value: "5432"
+            {{- else }}
+            - name: DB_HOST
+              value: {{ .Values.externalDatabase.host | default (.Values.services.api.env.DB_HOST | default "") | quote }}
+            - name: DB_PORT
+              value: {{ .Values.externalDatabase.port | default (.Values.services.api.env.DB_PORT | default "5432") | quote }}
+            {{- end }}
       containers:
         - name: migration
           securityContext:

--- a/charts/daytona/templates/api-migration-pre-deploy-job.yaml
+++ b/charts/daytona/templates/api-migration-pre-deploy-job.yaml
@@ -26,6 +26,30 @@ spec:
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       restartPolicy: Never
+      initContainers:
+        - name: wait-for-postgres
+          image: busybox:1.37
+          imagePullPolicy: IfNotPresent
+          command: ["sh", "-c"]
+          args:
+            - |
+              echo "Waiting for postgres at ${DB_HOST}:${DB_PORT}..."
+              until nc -z -w 2 "${DB_HOST}" "${DB_PORT}"; do
+                sleep 3
+              done
+              echo "postgres reachable"
+          env:
+            {{- if .Values.postgresql.enabled }}
+            - name: DB_HOST
+              value: {{ printf "%s-postgresql" .Release.Name | quote }}
+            - name: DB_PORT
+              value: "5432"
+            {{- else }}
+            - name: DB_HOST
+              value: {{ .Values.externalDatabase.host | default (.Values.services.api.env.DB_HOST | default "") | quote }}
+            - name: DB_PORT
+              value: {{ .Values.externalDatabase.port | default (.Values.services.api.env.DB_PORT | default "5432") | quote }}
+            {{- end }}
       containers:
         - name: migration
           securityContext:


### PR DESCRIPTION
Add a wait-for-postgres initContainer to all three migrations jobs. When postgresql.enabled is true, the chart's post-install hook can fire before the bundled postgres StatefulSet pod is Ready, causing the migration container to fail on first connection attempt. The new initContainer polls postgres TCP until reachable, then exits.

Handles both bundled and external-database case.

Verified on AKS.

<img width="740" height="269" alt="Pre-Deploy-Verify" src="https://github.com/user-attachments/assets/b4ca618d-7522-4c40-b073-0c12e2058f31" />

<img width="740" height="223" alt="Post-Deploy-Verify" src="https://github.com/user-attachments/assets/ab85e010-197e-4770-b197-b0467a68c82e" />
