### PR TITLE
docs(runner): node labeling requirement in prereqs + NOTES

### DIFF
--- a/charts/daytona/README.md
+++ b/charts/daytona/README.md
@@ -77,6 +77,8 @@ graph TB
 - Helm 3.2.0+
 - At least one worker node labeled `daytona-sandbox-c=true` for the runner DaemonSet to schedule on (see [Kubernetes Runner Autoscaling](#kubernetes-runner-autoscaling-runner--runner-manager) for the full node pool setup).
 
+- Runners must use Ubuntu 24.04 OS
+
 ## Installing the Chart
 
 To install the chart with the release name `daytona`:
@@ -643,7 +645,7 @@ kubectl port-forward svc/daytona-pgadmin4 8083:80
 
 ## Runner Deployment
 
-After successfully deploying the Daytona platform, you can deploy runners on clean Linux hosts to execute AI workloads:
+After successfully deploying the Daytona platform, you can deploy runners on clean Linux (Ubuntu 24.04 OS) hosts to execute AI workloads:
 
 ### 1. Generate Admin API Key
 ```bash

--- a/charts/daytona/README.md
+++ b/charts/daytona/README.md
@@ -75,6 +75,7 @@ graph TB
 
 - Kubernetes 1.19+
 - Helm 3.2.0+
+- At least one worker node labeled `daytona-sandbox-c=true` for the runner DaemonSet to schedule on (see [Kubernetes Runner Autoscaling](#kubernetes-runner-autoscaling-runner--runner-manager) for the full node pool setup).
 
 ## Installing the Chart
 

--- a/charts/daytona/templates/NOTES.txt
+++ b/charts/daytona/templates/NOTES.txt
@@ -52,5 +52,18 @@
    # Username: {{ .Values.minio.rootUser }}
    # Password: {{ .Values.minio.rootPassword }}
 {{ end }}
+{{- if .Values.services.runner.enabled }}
+
+⚠️  Sandbox runners require a labeled node:
+   The runner DaemonSet schedules only on nodes labeled `daytona-sandbox-c=true`.
+   Without at least one labeled node, sandbox creation will fail with
+   "Snapshot default-snapshot is pending".
+
+   # Label an existing node:
+   kubectl label node <node-name> daytona-sandbox-c=true
+
+   # For the full production node pool setup (dedicated pool, taints, autoscaling),
+   # see the chart README's "Kubernetes Runner Autoscaling" section.
+{{- end }}
 
 💡 TIP: Run 'kubectl get pods -n {{ include "daytona.namespace" . }}' to check if all services are running!

--- a/runner/README.md
+++ b/runner/README.md
@@ -3,7 +3,7 @@ To install and register a Daytona Runner on your system, follow these steps:
 
 ## Prerequisites
 
-- **Supported OS Architecture:** AMD64/x86_64
+- **Supported OS Architecture:** AMD64/x86_64, Ubuntu 24.04 OS
 - **Docker:** The script will install Docker if not present.
 - **Systemd:** Required for service management.
 


### PR DESCRIPTION
The runner DaemonSet only schedules on nodes labeled `daytona-sandbox-c=true`. The requirement is documented further down in the README, but it is not visible in either the Prerequisites section or in the NOTES.txt splash screen. This makes it non-obvious and difficult for first-time users to get a successful install.

Add: A one line prereq and a conditional block to NOTES.txt that prints only when services.runner.enabled is true. There is no behavior change to the code.