### PR TITLE
feat: expose dockerInstaller.insecureRegistries in daytona and daytona-region

### DIFF
--- a/charts/daytona-region/templates/runner-daemonset.yaml
+++ b/charts/daytona-region/templates/runner-daemonset.yaml
@@ -466,6 +466,9 @@ spec:
                 {{- if .Values.services.runner.dockerInstaller.dns }}
                 "dns": {{ .Values.services.runner.dockerInstaller.dns | toJson }},
                 {{- end }}
+                {{- if .Values.services.runner.dockerInstaller.insecureRegistries }}
+                "insecure-registries": {{ .Values.services.runner.dockerInstaller.insecureRegistries | toJson }},
+                {{- end }}
                 "log-driver": "json-file",
                 "log-opts": {
                   "max-size": "10m",

--- a/charts/daytona-region/values.yaml
+++ b/charts/daytona-region/values.yaml
@@ -434,7 +434,31 @@ services:
       enabled: true
       image: "ubuntu:22.04"
       xfsStorageSize: "50G"
+      # DNS resolvers added to /etc/docker/daemon.json. All containers started
+      # by this Docker daemon will use these resolvers.
+      # Example:
+      #   dns:
+      #     - "10.0.0.2"
+      #     - "8.8.8.8"
       dns: []
+      # Registries Docker is allowed to pull from without TLS validation.
+      # Use this when:
+      #   - your internal registry is plain HTTP, or
+      #   - it uses HTTPS with a self-signed/internal CA and you'd rather
+      #     not inject that CA into the host trust store on every node.
+      # Each entry is "host" or "host:port". Setting this lets you avoid
+      # issuing or distributing TLS certs for internal sandbox image hosts
+      # entirely.
+      # Example:
+      #   insecureRegistries:
+      #     - "harbor.internal.example.com"     # HTTPS, self-signed cert
+      #     - "registry.internal.svc:5000"      # plain HTTP
+      #     - "10.0.0.5:5000"                   # IP form
+      # NOTE: if registryProxy.enabled=true below, you almost always also
+      # want to list the proxy's localhost endpoint here (e.g.
+      # "localhost:5000") so Docker doesn't try to TLS-validate the
+      # in-pod socat forwarder.
+      insecureRegistries: []
       airgapped:
         enabled: false
         packagesImage: "daytonaio/daytona-runner-packages:v0.0.2"

--- a/charts/daytona/templates/runner-daemonset.yaml
+++ b/charts/daytona/templates/runner-daemonset.yaml
@@ -468,6 +468,9 @@ spec:
                 {{- if .Values.services.runner.dockerInstaller.dns }}
                 "dns": {{ .Values.services.runner.dockerInstaller.dns | toJson }},
                 {{- end }}
+                {{- if .Values.services.runner.dockerInstaller.insecureRegistries }}
+                "insecure-registries": {{ .Values.services.runner.dockerInstaller.insecureRegistries | toJson }},
+                {{- end }}
                 "log-driver": "json-file",
                 "log-opts": {
                   "max-size": "10m",

--- a/charts/daytona/values.yaml
+++ b/charts/daytona/values.yaml
@@ -567,6 +567,24 @@ services:
       #     - "10.0.0.2"
       #     - "8.8.8.8"
       dns: []
+      # Registries Docker is allowed to pull from without TLS validation.
+      # Use this when:
+      #   - your internal registry is plain HTTP, or
+      #   - it uses HTTPS with a self-signed/internal CA and you'd rather
+      #     not inject that CA into the host trust store on every node.
+      # Each entry is "host" or "host:port". Setting this lets you avoid
+      # issuing or distributing TLS certs for internal sandbox image hosts
+      # entirely.
+      # Example:
+      #   insecureRegistries:
+      #     - "harbor.internal.example.com"     # HTTPS, self-signed cert
+      #     - "registry.internal.svc:5000"      # plain HTTP
+      #     - "10.0.0.5:5000"                   # IP form
+      # NOTE: if registryProxy.enabled=true above, you almost always also
+      # want to list the proxy's localhost endpoint here (e.g.
+      # "localhost:5000") so Docker doesn't try to TLS-validate the
+      # in-pod socat forwarder.
+      insecureRegistries: []
       # Airgapped mode - use pre-packaged dependencies instead of downloading from internet
       airgapped:
         enabled: false


### PR DESCRIPTION
re-introduces the availability of insecureRegistries to avoid over architecting the configuration


Wire a list of insecure-registries entries through dockerInstaller into the rendered /etc/docker/daemon.json on each runner node. Lets BYOC operators point runner nodes at HTTP or self-signed-HTTPS internal registries without distributing a CA bundle to every node, and pairs cleanly with the existing registryProxy sidecar.
Backward compatible: empty default (insecureRegistries: []) omits the field from daemon.json, so behavior is identical to upstream for anyone not setting it. Mirrored across charts/daytona-region/ and charts/daytona/ to keep the two runner daemonsets in sync.