### PR TITLE
Make BusyBox helper images configurable

### DIFF
--- a/charts/daytona/Chart.yaml
+++ b/charts/daytona/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: daytona
 description: A Helm chart for Daytona - Secure Infrastructure for Running AI Code
 type: application
-version: 0.0.24
+version: 0.0.25
 appVersion: "v0.132.0"
 keywords:
   - ai

--- a/charts/daytona/README.md
+++ b/charts/daytona/README.md
@@ -229,6 +229,15 @@ When `services.api.autoscaling.enabled=true`, the HPA will manage the replica co
 
 **Note:** When HPA is enabled, ensure that resource requests are set in `services.api.resources.requests` for accurate scaling decisions.
 
+### API Migration Job Configuration
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `apiMigration.waitForPostgres.image.registry` | Wait-for-Postgres init container image registry | `docker.io` |
+| `apiMigration.waitForPostgres.image.repository` | Wait-for-Postgres init container image repository | `library/busybox` |
+| `apiMigration.waitForPostgres.image.tag` | Wait-for-Postgres init container image tag | `"1.37"` |
+| `apiMigration.waitForPostgres.image.pullPolicy` | Wait-for-Postgres init container image pull policy | `IfNotPresent` |
+
 ### Proxy Service Configuration
 
 | Parameter | Description | Default |
@@ -423,6 +432,11 @@ Dex is a simple IdP (Identity Provider) used for testing and development. For pr
 | `dex.image.registry` | Dex image registry | `docker.io` |
 | `dex.image.repository` | Dex image repository | `dexidp/dex` |
 | `dex.image.tag` | Dex image tag | `"v2.42.0"` |
+| `dex.image.pullPolicy` | Dex image pull policy | `IfNotPresent` |
+| `dex.volumePermissions.image.registry` | Dex volume-permissions init container image registry | `docker.io` |
+| `dex.volumePermissions.image.repository` | Dex volume-permissions init container image repository | `library/busybox` |
+| `dex.volumePermissions.image.tag` | Dex volume-permissions init container image tag | `latest` |
+| `dex.volumePermissions.image.pullPolicy` | Dex volume-permissions init container image pull policy | `IfNotPresent` |
 | `dex.service.port` | Dex service port | `5556` |
 | `dex.persistence.enabled` | Enable Dex persistence | `true` |
 | `dex.persistence.size` | Dex persistence size | `1Gi` |

--- a/charts/daytona/templates/api-migration-init-job.yaml
+++ b/charts/daytona/templates/api-migration-init-job.yaml
@@ -1,3 +1,11 @@
+{{- $apiMigration := .Values.apiMigration | default dict }}
+{{- $waitForPostgres := $apiMigration.waitForPostgres | default dict }}
+{{- $waitForPostgresImage := $waitForPostgres.image | default dict }}
+{{- $waitForPostgresImageRegistryValue := "docker.io" }}
+{{- if hasKey $waitForPostgresImage "registry" }}
+{{- $waitForPostgresImageRegistryValue = $waitForPostgresImage.registry }}
+{{- end }}
+{{- $waitForPostgresImageRegistry := include "daytona.imageRegistry" (dict "Values" .Values "serviceRegistry" $waitForPostgresImageRegistryValue) }}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -28,8 +36,8 @@ spec:
       restartPolicy: Never
       initContainers:
         - name: wait-for-postgres
-          image: busybox:1.37
-          imagePullPolicy: IfNotPresent
+          image: "{{ if $waitForPostgresImageRegistry }}{{ $waitForPostgresImageRegistry }}/{{ end }}{{ $waitForPostgresImage.repository | default "library/busybox" }}:{{ $waitForPostgresImage.tag | default "1.37" }}"
+          imagePullPolicy: {{ $waitForPostgresImage.pullPolicy | default "IfNotPresent" }}
           command: ["sh", "-c"]
           args:
             - |

--- a/charts/daytona/templates/api-migration-post-deploy-job.yaml
+++ b/charts/daytona/templates/api-migration-post-deploy-job.yaml
@@ -1,3 +1,11 @@
+{{- $apiMigration := .Values.apiMigration | default dict }}
+{{- $waitForPostgres := $apiMigration.waitForPostgres | default dict }}
+{{- $waitForPostgresImage := $waitForPostgres.image | default dict }}
+{{- $waitForPostgresImageRegistryValue := "docker.io" }}
+{{- if hasKey $waitForPostgresImage "registry" }}
+{{- $waitForPostgresImageRegistryValue = $waitForPostgresImage.registry }}
+{{- end }}
+{{- $waitForPostgresImageRegistry := include "daytona.imageRegistry" (dict "Values" .Values "serviceRegistry" $waitForPostgresImageRegistryValue) }}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -28,8 +36,8 @@ spec:
       restartPolicy: Never
       initContainers:
         - name: wait-for-postgres
-          image: busybox:1.37
-          imagePullPolicy: IfNotPresent
+          image: "{{ if $waitForPostgresImageRegistry }}{{ $waitForPostgresImageRegistry }}/{{ end }}{{ $waitForPostgresImage.repository | default "library/busybox" }}:{{ $waitForPostgresImage.tag | default "1.37" }}"
+          imagePullPolicy: {{ $waitForPostgresImage.pullPolicy | default "IfNotPresent" }}
           command: ["sh", "-c"]
           args:
             - |

--- a/charts/daytona/templates/api-migration-pre-deploy-job.yaml
+++ b/charts/daytona/templates/api-migration-pre-deploy-job.yaml
@@ -1,3 +1,11 @@
+{{- $apiMigration := .Values.apiMigration | default dict }}
+{{- $waitForPostgres := $apiMigration.waitForPostgres | default dict }}
+{{- $waitForPostgresImage := $waitForPostgres.image | default dict }}
+{{- $waitForPostgresImageRegistryValue := "docker.io" }}
+{{- if hasKey $waitForPostgresImage "registry" }}
+{{- $waitForPostgresImageRegistryValue = $waitForPostgresImage.registry }}
+{{- end }}
+{{- $waitForPostgresImageRegistry := include "daytona.imageRegistry" (dict "Values" .Values "serviceRegistry" $waitForPostgresImageRegistryValue) }}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -28,8 +36,8 @@ spec:
       restartPolicy: Never
       initContainers:
         - name: wait-for-postgres
-          image: busybox:1.37
-          imagePullPolicy: IfNotPresent
+          image: "{{ if $waitForPostgresImageRegistry }}{{ $waitForPostgresImageRegistry }}/{{ end }}{{ $waitForPostgresImage.repository | default "library/busybox" }}:{{ $waitForPostgresImage.tag | default "1.37" }}"
+          imagePullPolicy: {{ $waitForPostgresImage.pullPolicy | default "IfNotPresent" }}
           command: ["sh", "-c"]
           args:
             - |

--- a/charts/daytona/templates/dex-deployment.yaml
+++ b/charts/daytona/templates/dex-deployment.yaml
@@ -1,4 +1,8 @@
 {{- if .Values.dex.enabled }}
+{{- $dexImage := .Values.dex.image }}
+{{- $dexVolumePermissionsImage := .Values.dex.volumePermissions.image }}
+{{- $dexImageRegistry := include "daytona.imageRegistry" (dict "Values" .Values "serviceRegistry" $dexImage.registry) }}
+{{- $dexVolumePermissionsImageRegistry := include "daytona.imageRegistry" (dict "Values" .Values "serviceRegistry" $dexVolumePermissionsImage.registry) }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -27,7 +31,8 @@ spec:
       {{- end }}
       initContainers:
         - name: volume-permissions
-          image: busybox:latest
+          image: "{{ if $dexVolumePermissionsImageRegistry }}{{ $dexVolumePermissionsImageRegistry }}/{{ end }}{{ $dexVolumePermissionsImage.repository }}:{{ $dexVolumePermissionsImage.tag | default "latest" }}"
+          imagePullPolicy: {{ $dexVolumePermissionsImage.pullPolicy | default "IfNotPresent" }}
           command:
             - sh
             - -c
@@ -41,8 +46,8 @@ spec:
               mountPath: /var/dex
       containers:
         - name: dex
-          image: "{{ if .Values.dex.image.registry }}{{ .Values.dex.image.registry }}/{{ end }}{{ .Values.dex.image.repository }}:{{ .Values.dex.image.tag | default "v2.42.0" }}"
-          imagePullPolicy: {{ .Values.dex.image.pullPolicy | default "IfNotPresent" }}
+          image: "{{ if $dexImageRegistry }}{{ $dexImageRegistry }}/{{ end }}{{ $dexImage.repository }}:{{ $dexImage.tag | default "v2.42.0" }}"
+          imagePullPolicy: {{ $dexImage.pullPolicy | default "IfNotPresent" }}
           command:
             - sh
             - -c

--- a/charts/daytona/values.yaml
+++ b/charts/daytona/values.yaml
@@ -641,6 +641,13 @@ dex:
     registry: docker.io
     repository: dexidp/dex
     tag: "v2.42.0"
+    pullPolicy: IfNotPresent
+  volumePermissions:
+    image:
+      registry: docker.io
+      repository: library/busybox
+      tag: latest
+      pullPolicy: IfNotPresent
   service:
     port: 5556
   persistence:
@@ -717,6 +724,15 @@ dex:
         username: "admin"
         password: "$2y$10$pQ8jbpk6RWHx/uYJtDey.uCTzVl2ZXg569tp63PE9uisbCYzoARW6"
         userID: "1234"
+
+# API migration job configuration
+apiMigration:
+  waitForPostgres:
+    image:
+      registry: docker.io
+      repository: library/busybox
+      tag: "1.37"
+      pullPolicy: IfNotPresent
 
 # Redis configuration
 redis:


### PR DESCRIPTION
## Summary
- Make the Dex volume-permissions BusyBox image configurable.
- Make the wait-for-Postgres BusyBox image used by API migration jobs configurable.
- Route Dex and BusyBox helper images through the existing `global.imageRegistry` helper so private registry mirrors can be used without patching rendered workloads.

## Why
Clusters that block Docker Hub currently fail when these helper containers try to pull hardcoded BusyBox images. This lets operators point the chart at a mirrored registry while preserving the current Docker Hub defaults.

## Testing
- `helm lint charts/daytona`
- `helm template daytona charts/daytona --set global.imageRegistry=registry.ryvn.app/athenaintel-docker --show-only templates/dex-deployment.yaml | rg 'image:|imagePullPolicy'`\n- `helm template daytona charts/daytona --set global.imageRegistry=registry.ryvn.app/athenaintel-docker --show-only templates/api-migration-init-job.yaml | rg 'image:|imagePullPolicy'`\n- `git diff --check`