### PR TITLE
fix(chart): fail closed on unset secrets; stop shipping default credentials

### DIFF
--- a/charts/daytona/Chart.yaml
+++ b/charts/daytona/Chart.yaml
@@ -2,8 +2,18 @@ apiVersion: v2
 name: daytona
 description: A Helm chart for Daytona - Secure Infrastructure for Running AI Code
 type: application
-version: 0.0.25
+# Minor bump: BREAKING - default secrets removed; installs fail closed until secrets are set.
+version: 0.1.0
 appVersion: "v0.132.0"
+annotations:
+  artifacthub.io/containsSecurityUpdates: "true"
+  artifacthub.io/changes: |
+    - kind: security
+      description: No longer ship default credentials or SSH keys in values.yaml; fail closed on unset or known-default secrets (security.validateSecrets)
+    - kind: security
+      description: Remove the built-in Dex static admin (dev@daytona.io); a bcrypt password hash must now be supplied by the operator
+    - kind: changed
+      description: SSH gateway keys may be supplied via services.sshGateway.sshKeys.existingSecret; the runner inherits the gateway public key by default
 keywords:
   - ai
   - infrastructure

--- a/charts/daytona/README.md
+++ b/charts/daytona/README.md
@@ -90,6 +90,56 @@ To install with custom values:
 helm install daytona ./charts/daytona -f my-values.yaml
 ```
 
+## Required secrets
+
+The chart ships **no** default credentials or keys. By default (`security.validateSecrets: true`)
+it refuses to render until every secret below is set to a unique value. This is a fail-closed
+guardrail: a stock `helm install` stops with a list of what is missing rather than deploying
+with predictable, publicly known credentials.
+
+Set these in your values file before installing (quote all values so YAML does not coerce
+all-digit secrets into numbers):
+
+| Value | Purpose | Generate with |
+|-------|---------|---------------|
+| `services.api.env.ENCRYPTION_KEY` | Data-at-rest encryption (≥32 chars). **Back it up; losing it makes encrypted data unrecoverable.** | `openssl rand -base64 24 \| head -c 32` |
+| `services.api.env.ENCRYPTION_SALT` | Key-derivation salt | `openssl rand -base64 24` |
+| `services.api.env.RUNNER_MANAGER_API_KEY` | API → runner-manager auth. **Must equal `services.runnermanager.env.API_TOKEN`.** | `openssl rand -hex 32` |
+| `services.runnermanager.env.API_TOKEN` | Same shared secret as above | (reuse the value above) |
+| `services.runnermanager.env.SYSTEM_API_TOKEN` | System token. **Must equal `services.runner.env.SYSTEM_API_TOKEN`.** | `openssl rand -hex 32` |
+| `services.runnermanager.env.API_KEY` | Runner-manager API key | `openssl rand -hex 32` |
+| `services.runner.env.API_TOKEN` | Runner API token | `openssl rand -hex 32` |
+| `services.runner.env.SYSTEM_API_TOKEN` | Same shared secret as runner-manager's | (reuse the value above) |
+| `services.proxy.env.PROXY_API_KEY` | Proxy auth key | `openssl rand -hex 32` |
+| `services.sshGateway.apiKey` | SSH gateway → API auth key | `openssl rand -hex 32` |
+| `services.sshGateway.sshKeys.*` | SSH gateway keypairs (see below) | `ssh-keygen` |
+| `dex.config.staticPasswords[].password` | Dex login (bcrypt hash). Omit the entry / set `[]` if using an upstream IdP. | `htpasswd -BnC 10 "" <<< 'your-password' \| tr -d ':\n'` |
+
+### SSH gateway keys
+
+Generate two ed25519 keypairs and base64-encode them, or point `sshKeys.existingSecret` at a
+pre-created Secret (containing `SSH_PRIVATE_KEY`, `SSH_PRIVATE_PUB_KEY`, `SSH_HOST_KEY`, `API_KEY`)
+managed by External Secrets / Sealed Secrets:
+
+```bash
+ssh-keygen -t ed25519 -f client  -N "" -C client-key
+ssh-keygen -t ed25519 -f gateway -N "" -C server-key
+# privClientSSHKey:  base64 -w0 client
+# pubClientSSHKey:   base64 -w0 client.pub
+# privGatewaySSHKey: base64 -w0 gateway
+```
+
+> If you deliver all secrets out-of-band (existingSecret / Secrets Store CSI Driver /
+> `extraEnv` secretKeyRef), set `security.validateSecrets: false` to skip the guardrail.
+
+### Upgrading from a release that shipped default secrets
+
+Earlier chart versions shipped working default credentials and an embedded SSH keypair in
+`values.yaml`. Those values are present in this repo's public history and must be considered
+compromised. After upgrading, **rotate every secret listed above**: set fresh values and, for
+the SSH gateway, generate new keypairs. Reusing the previously shipped keys means anyone with
+the public chart history holds your gateway private keys.
+
 ## Uninstalling the Chart
 
 To uninstall/delete the `daytona` deployment:
@@ -286,7 +336,7 @@ When `services.api.autoscaling.enabled=true`, the HPA will manage the replica co
 
 - `PROXY_PORT`: Proxy port | `""` (defaults to 4000 if not set)
 - `PROXY_DOMAIN`: Proxy domain (auto-generated as `proxy.{{baseDomain}}:{{PROXY_PORT}}` if empty)
-- `PROXY_API_KEY`: Proxy API key | `"super_secret_key"`
+- `PROXY_API_KEY`: Proxy API key | `""` (REQUIRED, see "Required secrets")
 - `PROXY_PROTOCOL`: Proxy protocol | `"http"`
 - `OIDC_CLIENT_SECRET`: OIDC client secret | `""`
 
@@ -323,7 +373,8 @@ When `services.proxy.autoscaling.enabled=true`, the HPA will manage the replica 
 | `services.sshGateway.serviceAccount.create` | Create SSH Gateway service account | `true` |
 | `services.sshGateway.serviceAccount.name` | SSH Gateway service account name | `""` |
 | `services.sshGateway.serviceAccount.annotations` | SSH Gateway service account annotations | `{}` |
-| `services.sshGateway.apiKey` | API key for SSH Gateway authentication | `"supersecretapikey"` |
+| `services.sshGateway.apiKey` | API key for SSH Gateway authentication | `""` (REQUIRED) |
+| `services.sshGateway.sshKeys.existingSecret` | Existing Secret with SSH keys + API_KEY (skips chart-managed Secret) | `""` |
 | `services.sshGateway.sshKeys.privClientSSHKey` | Private client SSH key (base64) | `""` |
 | `services.sshGateway.sshKeys.pubClientSSHKey` | Public client SSH key (base64) | `""` |
 | `services.sshGateway.sshKeys.privGatewaySSHKey` | Private gateway SSH key (base64) | `""` |

--- a/charts/daytona/README.md
+++ b/charts/daytona/README.md
@@ -129,8 +129,11 @@ ssh-keygen -t ed25519 -f gateway -N "" -C server-key
 # privGatewaySSHKey: base64 -w0 gateway
 ```
 
-> If you deliver all secrets out-of-band (existingSecret / Secrets Store CSI Driver /
-> `extraEnv` secretKeyRef), set `security.validateSecrets: false` to skip the guardrail.
+> `security.validateSecrets: false` skips validation of the env-delivered secrets
+> (encryption key, API keys, tokens) so you can inject them out-of-band via `extraEnv` or
+> the Secrets Store CSI Driver. The SSH gateway keys and the Dex password are written into
+> chart-managed resources and **always fail closed regardless of this flag**: for those, use
+> `sshKeys.existingSecret` and set `dex.config.staticPasswords: []` (or supply a hash).
 
 ### Upgrading from a release that shipped default secrets
 

--- a/charts/daytona/templates/NOTES.txt
+++ b/charts/daytona/templates/NOTES.txt
@@ -15,9 +15,15 @@
    # API: https://{{ $templatedApiHostname }}/api
 {{- if .Values.dex.enabled }}
    # Dex OIDC: https://{{ $templatedDexHostname }}/dex
-   # Dashboard Login Credentials:
+{{- if gt (len (.Values.dex.config.staticPasswords | default list)) 0 }}
+   # Dashboard login (Dex static user):
    # Username: {{ (index .Values.dex.config.staticPasswords 0).username | default "admin" }}
-   # Password: password (or whatever is set via hash)
+   # Email:    {{ (index .Values.dex.config.staticPasswords 0).email }}
+   # Password: the password whose bcrypt hash you set in dex.config.staticPasswords
+{{- else }}
+   # No Dex static login is configured (dex.config.staticPasswords is empty);
+   # configure a static password hash or an upstream connector before logging in.
+{{- end }}
 {{- end }}
 {{- else }}
    # For local development, set up port-forwards:
@@ -32,9 +38,15 @@
    # API: http://localhost:8080/api
 {{- if .Values.dex.enabled }}
    # Dex OIDC: http://localhost:5556/dex
-   # Dashboard Login Credentials:
+{{- if gt (len (.Values.dex.config.staticPasswords | default list)) 0 }}
+   # Dashboard login (Dex static user):
    # Username: {{ (index .Values.dex.config.staticPasswords 0).username | default "admin" }}
-   # Password: password (or whatever is set via hash)
+   # Email:    {{ (index .Values.dex.config.staticPasswords 0).email }}
+   # Password: the password whose bcrypt hash you set in dex.config.staticPasswords
+{{- else }}
+   # No Dex static login is configured (dex.config.staticPasswords is empty);
+   # configure a static password hash or an upstream connector before logging in.
+{{- end }}
 {{- end }}
 {{ end }}
 

--- a/charts/daytona/templates/_helpers.tpl
+++ b/charts/daytona/templates/_helpers.tpl
@@ -96,6 +96,20 @@ Create the name of the secret
 {{- end }}
 
 {{/*
+Name of the Secret holding the SSH gateway keys and API key.
+Resolves to the operator-provided existingSecret when set, otherwise the chart-managed
+Secret. The SSH gateway deployment and the chart-managed Secret template both use this
+helper so the name stays consistent.
+*/}}
+{{- define "daytona.sshSecretName" -}}
+{{- with .Values.services.sshGateway.sshKeys.existingSecret -}}
+{{- tpl . $ -}}
+{{- else -}}
+{{- printf "%s-ssh" (include "daytona.secretName" $) -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Get image registry (use global if set, otherwise service-specific)
 */}}
 {{- define "daytona.imageRegistry" -}}

--- a/charts/daytona/templates/_validation.tpl
+++ b/charts/daytona/templates/_validation.tpl
@@ -1,0 +1,72 @@
+{{/*
+Returns an error message when a secret value is missing, left at a value that was shipped
+with the chart, or shorter than a required minimum. Returns an empty string when the value
+is acceptable. Inputs: .v (value), .sentinel (optional shipped default), .min (optional
+minimum length), .label (values path shown to the operator).
+*/}}
+{{- define "daytona.checkSecret" -}}
+{{- $v := .v | toString | trim -}}
+{{- if eq $v "" -}}
+{{- printf "%s is required but no value is set" .label -}}
+{{- else if and .sentinel (eq $v (.sentinel | toString)) -}}
+{{- printf "%s is set to a value shipped with the chart and must be changed" .label -}}
+{{- else if and .min (lt (len $v) (.min | int)) -}}
+{{- printf "%s must be at least %d characters" .label (.min | int) -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Fail-closed validation of security-sensitive secrets. Aborts `helm install/upgrade/template`
+when a required secret is empty or still set to a value that was previously shipped as a
+default. Skipped entirely when security.validateSecrets is false (for setups that inject all
+secrets out-of-band via existingSecret / CSI / extraEnv).
+*/}}
+{{- define "daytona.validateSecrets" -}}
+{{- if .Values.security.validateSecrets -}}
+{{- $e := list -}}
+{{- $api := .Values.services.api.env -}}
+{{- $e = append $e (include "daytona.checkSecret" (dict "v" $api.ENCRYPTION_KEY "sentinel" "CHANGE_ME_32_CHARACTER_SECRET_K!" "min" 32 "label" "services.api.env.ENCRYPTION_KEY")) -}}
+{{- $e = append $e (include "daytona.checkSecret" (dict "v" $api.ENCRYPTION_SALT "sentinel" "CHANGE_ME_RANDOM_SALT_VALUE" "label" "services.api.env.ENCRYPTION_SALT")) -}}
+{{- $e = append $e (include "daytona.checkSecret" (dict "v" $api.RUNNER_MANAGER_API_KEY "sentinel" "runner_manager_secret_key" "label" "services.api.env.RUNNER_MANAGER_API_KEY")) -}}
+{{- $e = append $e (include "daytona.checkSecret" (dict "v" .Values.services.proxy.env.PROXY_API_KEY "sentinel" "super_secret_key" "label" "services.proxy.env.PROXY_API_KEY")) -}}
+{{- if .Values.services.sshGateway.enabled -}}
+{{- /* When existingSecret is set, the operator's Secret supplies the keys and API_KEY,
+       so none of these are required in values. */ -}}
+{{- if not .Values.services.sshGateway.sshKeys.existingSecret -}}
+{{- $e = append $e (include "daytona.checkSecret" (dict "v" .Values.services.sshGateway.apiKey "sentinel" "supersecretapikey" "label" "services.sshGateway.apiKey (or set sshKeys.existingSecret)")) -}}
+{{- $e = append $e (include "daytona.checkSecret" (dict "v" .Values.services.sshGateway.sshKeys.privClientSSHKey "label" "services.sshGateway.sshKeys.privClientSSHKey (or set sshKeys.existingSecret)")) -}}
+{{- $e = append $e (include "daytona.checkSecret" (dict "v" .Values.services.sshGateway.sshKeys.pubClientSSHKey "label" "services.sshGateway.sshKeys.pubClientSSHKey (or set sshKeys.existingSecret)")) -}}
+{{- $e = append $e (include "daytona.checkSecret" (dict "v" .Values.services.sshGateway.sshKeys.privGatewaySSHKey "label" "services.sshGateway.sshKeys.privGatewaySSHKey (or set sshKeys.existingSecret)")) -}}
+{{- end -}}
+{{- end -}}
+{{- if .Values.services.runnermanager.enabled -}}
+{{- $e = append $e (include "daytona.checkSecret" (dict "v" .Values.services.runnermanager.env.API_TOKEN "sentinel" "runner_manager_secret_key" "label" "services.runnermanager.env.API_TOKEN")) -}}
+{{- $e = append $e (include "daytona.checkSecret" (dict "v" .Values.services.runnermanager.env.SYSTEM_API_TOKEN "sentinel" "system_api_token" "label" "services.runnermanager.env.SYSTEM_API_TOKEN")) -}}
+{{- $e = append $e (include "daytona.checkSecret" (dict "v" .Values.services.runnermanager.env.API_KEY "sentinel" "secret_api_key" "label" "services.runnermanager.env.API_KEY")) -}}
+{{- end -}}
+{{- if .Values.services.runner.enabled -}}
+{{- $e = append $e (include "daytona.checkSecret" (dict "v" .Values.services.runner.env.API_TOKEN "sentinel" "secret_api_token" "label" "services.runner.env.API_TOKEN")) -}}
+{{- $e = append $e (include "daytona.checkSecret" (dict "v" .Values.services.runner.env.SYSTEM_API_TOKEN "sentinel" "system_api_token" "label" "services.runner.env.SYSTEM_API_TOKEN")) -}}
+{{- end -}}
+{{- if .Values.dex.enabled -}}
+{{- range $i, $p := .Values.dex.config.staticPasswords -}}
+{{- $e = append $e (include "daytona.checkSecret" (dict "v" $p.password "sentinel" "$2a$10$2b2cU8CPhOTaGrs1HRQuAueS7JTT5ZHsHSzYiFPm1leZck7Mc8T4W" "label" (printf "dex.config.staticPasswords[%d].password (bcrypt hash)" $i))) -}}
+{{- end -}}
+{{- end -}}
+{{- /* Paired secrets must match across components */ -}}
+{{- $rmkApi := $api.RUNNER_MANAGER_API_KEY | toString -}}
+{{- $rmkRm := .Values.services.runnermanager.env.API_TOKEN | toString -}}
+{{- if and .Values.services.runnermanager.enabled (ne $rmkApi "") (ne $rmkRm "") (ne $rmkApi $rmkRm) -}}
+{{- $e = append $e "services.api.env.RUNNER_MANAGER_API_KEY must equal services.runnermanager.env.API_TOKEN" -}}
+{{- end -}}
+{{- $satRm := .Values.services.runnermanager.env.SYSTEM_API_TOKEN | toString -}}
+{{- $satRun := .Values.services.runner.env.SYSTEM_API_TOKEN | toString -}}
+{{- if and .Values.services.runnermanager.enabled .Values.services.runner.enabled (ne $satRm "") (ne $satRun "") (ne $satRm $satRun) -}}
+{{- $e = append $e "services.runnermanager.env.SYSTEM_API_TOKEN must equal services.runner.env.SYSTEM_API_TOKEN" -}}
+{{- end -}}
+{{- $e = compact $e -}}
+{{- if gt (len $e) 0 -}}
+{{- fail (printf "\n\n[daytona] Refusing to render the chart - insecure or missing secret values:\n  - %s\n\nProvide unique values in your values file (see the chart README, \"Required secrets\"),\nor set security.validateSecrets=false if every secret is delivered out-of-band\n(existingSecret / Secrets Store CSI Driver / extraEnv secretKeyRef).\n" (join "\n  - " $e)) -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}

--- a/charts/daytona/templates/api-deployment.yaml
+++ b/charts/daytona/templates/api-deployment.yaml
@@ -170,12 +170,12 @@ spec:
             - name: SSH_GATEWAY_PUBLIC_KEY
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "daytona.secretName" . }}-ssh
+                  name: {{ include "daytona.sshSecretName" . }}
                   key: SSH_PRIVATE_PUB_KEY
             - name: SSH_GATEWAY_API_KEY
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "daytona.secretName" . }}-ssh
+                  name: {{ include "daytona.sshSecretName" . }}
                   key: API_KEY
             {{- end }}
             # Harbor Registry Configuration

--- a/charts/daytona/templates/api-migration-init-job.yaml
+++ b/charts/daytona/templates/api-migration-init-job.yaml
@@ -189,12 +189,12 @@ spec:
             - name: SSH_GATEWAY_PUBLIC_KEY
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "daytona.secretName" . }}-ssh
+                  name: {{ include "daytona.sshSecretName" . }}
                   key: SSH_PRIVATE_PUB_KEY
             - name: SSH_GATEWAY_API_KEY
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "daytona.secretName" . }}-ssh
+                  name: {{ include "daytona.sshSecretName" . }}
                   key: API_KEY
             {{- end }}
             # Harbor Registry Configuration

--- a/charts/daytona/templates/api-migration-post-deploy-job.yaml
+++ b/charts/daytona/templates/api-migration-post-deploy-job.yaml
@@ -189,12 +189,12 @@ spec:
             - name: SSH_GATEWAY_PUBLIC_KEY
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "daytona.secretName" . }}-ssh
+                  name: {{ include "daytona.sshSecretName" . }}
                   key: SSH_PRIVATE_PUB_KEY
             - name: SSH_GATEWAY_API_KEY
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "daytona.secretName" . }}-ssh
+                  name: {{ include "daytona.sshSecretName" . }}
                   key: API_KEY
             {{- end }}
             # Harbor Registry Configuration

--- a/charts/daytona/templates/api-migration-pre-deploy-job.yaml
+++ b/charts/daytona/templates/api-migration-pre-deploy-job.yaml
@@ -189,12 +189,12 @@ spec:
             - name: SSH_GATEWAY_PUBLIC_KEY
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "daytona.secretName" . }}-ssh
+                  name: {{ include "daytona.sshSecretName" . }}
                   key: SSH_PRIVATE_PUB_KEY
             - name: SSH_GATEWAY_API_KEY
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "daytona.secretName" . }}-ssh
+                  name: {{ include "daytona.sshSecretName" . }}
                   key: API_KEY
             {{- end }}
             # Harbor Registry Configuration

--- a/charts/daytona/templates/dex-configmap.yaml
+++ b/charts/daytona/templates/dex-configmap.yaml
@@ -56,12 +56,15 @@ data:
           {{- end }}
         name: {{ .Values.dex.config.clientName | default "Daytona" | quote }}
         public: true
-    enablePasswordDB: true
+    {{- $staticPasswords := .Values.dex.config.staticPasswords | default list }}
+    enablePasswordDB: {{ gt (len $staticPasswords) 0 }}
+    {{- if gt (len $staticPasswords) 0 }}
     staticPasswords:
-      {{- range .Values.dex.config.staticPasswords | default (list (dict "email" "dev@daytona.io" "password" "$2a$10$2b2cU8CPhOTaGrs1HRQuAueS7JTT5ZHsHSzYiFPm1leZck7Mc8T4W" "username" "admin" "userID" "1234")) }}
-      - email: {{ .email | quote }}
+      {{- range $staticPasswords }}
+      - email: {{ required "dex.config.staticPasswords entry requires 'email'" .email | quote }}
         hash: {{ .password | quote }}
-        username: {{ .username | quote }}
-        userID: {{ .userID | quote }}
+        username: {{ .username | default "admin" | quote }}
+        userID: {{ .userID | default (.email | sha256sum | trunc 8) | quote }}
       {{- end }}
+    {{- end }}
 {{- end }}

--- a/charts/daytona/templates/dex-configmap.yaml
+++ b/charts/daytona/templates/dex-configmap.yaml
@@ -62,7 +62,7 @@ data:
     staticPasswords:
       {{- range $staticPasswords }}
       - email: {{ required "dex.config.staticPasswords entry requires 'email'" .email | quote }}
-        hash: {{ .password | quote }}
+        hash: {{ required "dex.config.staticPasswords entry requires a bcrypt 'password' hash; no default is shipped (use staticPasswords: [] to disable static login)" .password | quote }}
         username: {{ .username | default "admin" | quote }}
         userID: {{ .userID | default (.email | sha256sum | trunc 8) | quote }}
       {{- end }}

--- a/charts/daytona/templates/runner-daemonset.yaml
+++ b/charts/daytona/templates/runner-daemonset.yaml
@@ -598,7 +598,18 @@ spec:
             - name: AWS_DEFAULT_BUCKET
               value: {{ .Values.services.runner.env.AWS_DEFAULT_BUCKET | default "" | quote }}
             - name: SSH_PUBLIC_KEY
-              value: {{ .Values.services.runner.env.SSH_PUBLIC_KEY | default "" | quote }}
+            {{- if .Values.services.runner.env.SSH_PUBLIC_KEY }}
+              value: {{ .Values.services.runner.env.SSH_PUBLIC_KEY | quote }}
+            {{- else if .Values.services.sshGateway.enabled }}
+              {{- /* Inherit the gateway client public key from the SSH secret so this works
+                     identically for chart-managed keys and sshKeys.existingSecret. */}}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "daytona.sshSecretName" . }}
+                  key: SSH_PRIVATE_PUB_KEY
+            {{- else }}
+              value: ""
+            {{- end }}
             # Pod metadata
             - name: NODE_NAME
               valueFrom:

--- a/charts/daytona/templates/runner-manager-deployment.yaml
+++ b/charts/daytona/templates/runner-manager-deployment.yaml
@@ -57,7 +57,7 @@ spec:
             {{- end }}
             # System API Token
             - name: SYSTEM_API_TOKEN
-              value: {{ .Values.services.runnermanager.env.SYSTEM_API_TOKEN | default "system_api_token" | quote }}
+              value: {{ .Values.services.runnermanager.env.SYSTEM_API_TOKEN | default "" | quote }}
             # Provider Configuration
             - name: PROVIDER_TYPE
               value: {{ .Values.services.runnermanager.env.PROVIDER_TYPE | default "kubernetes" | quote }}
@@ -76,7 +76,7 @@ spec:
             {{- end }}
             # API Key
             - name: API_KEY
-              value: {{ .Values.services.runnermanager.env.API_KEY | default "secret_api_key" | quote }}
+              value: {{ .Values.services.runnermanager.env.API_KEY | default "" | quote }}
             # Server URL - Auto-generated as "https://{{.Values.baseDomain}}/api" if not set or empty
             - name: SERVER_URL
               value: {{ if .Values.services.runnermanager.env.SERVER_URL }}{{ .Values.services.runnermanager.env.SERVER_URL | quote }}{{ else }}{{ printf "https://%s/api" .Values.baseDomain | quote }}{{ end }}

--- a/charts/daytona/templates/ssh-gateway-deployment.yaml
+++ b/charts/daytona/templates/ssh-gateway-deployment.yaml
@@ -59,7 +59,7 @@ spec:
               value: "http://{{ include "daytona.fullname" . }}-api:{{ .Values.services.api.env.PORT }}/api"
           envFrom:
             - secretRef:
-                name: {{ include "daytona.secretName" . }}-ssh
+                name: {{ include "daytona.sshSecretName" . }}
           resources:
             {{- toYaml .Values.services.sshGateway.resources | nindent 12 }}
           {{- if .Values.services.sshGateway.extraVolumeMounts }}

--- a/charts/daytona/templates/ssh-gateway-secret.yaml
+++ b/charts/daytona/templates/ssh-gateway-secret.yaml
@@ -1,8 +1,11 @@
-{{- if .Values.services.sshGateway.enabled }}
+{{- if and .Values.services.sshGateway.enabled (not .Values.services.sshGateway.sshKeys.existingSecret) }}
+{{- /* When sshKeys.existingSecret is set, the operator owns this Secret and the chart
+       templates nothing here. These values are enforced fail-closed (non-empty, not a
+       shipped default) by templates/_validation.tpl when security.validateSecrets is true. */ -}}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "daytona.secretName" . }}-ssh
+  name: {{ include "daytona.sshSecretName" . }}
   namespace: {{ include "daytona.namespace" . }}
   labels:
     {{- include "daytona.labels" . | nindent 4 }}

--- a/charts/daytona/templates/ssh-gateway-secret.yaml
+++ b/charts/daytona/templates/ssh-gateway-secret.yaml
@@ -1,7 +1,8 @@
 {{- if and .Values.services.sshGateway.enabled (not .Values.services.sshGateway.sshKeys.existingSecret) }}
 {{- /* When sshKeys.existingSecret is set, the operator owns this Secret and the chart
-       templates nothing here. These values are enforced fail-closed (non-empty, not a
-       shipped default) by templates/_validation.tpl when security.validateSecrets is true. */ -}}
+       templates nothing here (the `if` above is false). For chart-managed keys, the
+       `required` filters below fail closed independently of security.validateSecrets,
+       as defense-in-depth alongside templates/_validation.tpl. */ -}}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -11,8 +12,8 @@ metadata:
     {{- include "daytona.labels" . | nindent 4 }}
 type: Opaque
 data:
-  SSH_PRIVATE_KEY: {{ .Values.services.sshGateway.sshKeys.privClientSSHKey | trim | b64enc }}
-  SSH_PRIVATE_PUB_KEY: {{ .Values.services.sshGateway.sshKeys.pubClientSSHKey | trim | b64enc }}
-  SSH_HOST_KEY: {{ .Values.services.sshGateway.sshKeys.privGatewaySSHKey | trim | b64enc }}
-  API_KEY: {{ .Values.services.sshGateway.apiKey | b64enc }}
+  SSH_PRIVATE_KEY: {{ required "services.sshGateway.sshKeys.privClientSSHKey is required (or set sshKeys.existingSecret)" .Values.services.sshGateway.sshKeys.privClientSSHKey | trim | b64enc }}
+  SSH_PRIVATE_PUB_KEY: {{ required "services.sshGateway.sshKeys.pubClientSSHKey is required (or set sshKeys.existingSecret)" .Values.services.sshGateway.sshKeys.pubClientSSHKey | trim | b64enc }}
+  SSH_HOST_KEY: {{ required "services.sshGateway.sshKeys.privGatewaySSHKey is required (or set sshKeys.existingSecret)" .Values.services.sshGateway.sshKeys.privGatewaySSHKey | trim | b64enc }}
+  API_KEY: {{ required "services.sshGateway.apiKey is required (or set sshKeys.existingSecret)" .Values.services.sshGateway.apiKey | b64enc }}
 {{- end }}

--- a/charts/daytona/templates/validate-secrets.yaml
+++ b/charts/daytona/templates/validate-secrets.yaml
@@ -1,0 +1,6 @@
+{{- /*
+Renders nothing, but runs fail-closed secret validation on every
+`helm install`, `helm upgrade`, `helm template` and `helm lint`.
+See templates/_validation.tpl and security.validateSecrets.
+*/ -}}
+{{- include "daytona.validateSecrets" . -}}

--- a/charts/daytona/values.yaml
+++ b/charts/daytona/values.yaml
@@ -12,6 +12,14 @@ global:
 # Base domain Daytona
 baseDomain: "daytona.example.com"
 
+# Security guardrails
+security:
+  # Fail-closed secret validation. When true (default), the chart refuses to render if a
+  # security-sensitive secret is left empty or set to a value that was previously shipped as
+  # a default. Set to false ONLY if every required secret is delivered out-of-band (via
+  # existingSecret, the Secrets Store CSI Driver, or extraEnv secretKeyRef).
+  validateSecrets: true
+
 # Service-specific configurations
 services:
   api:
@@ -86,12 +94,15 @@ services:
       SKIP_USER_EMAIL_VERIFICATION: "false"
 
       # Encryption configuration
-      # IMPORTANT: Change these values before deploying to production!
+      # REQUIRED: no default is shipped. The chart refuses to install until these are set
+      # (see security.validateSecrets). Losing ENCRYPTION_KEY makes existing encrypted data
+      # unrecoverable, so set it once and back it up.
       # ENCRYPTION_KEY must be a 32-character random string used for encrypting sensitive data at rest.
+      #   Generate with: openssl rand -base64 24 | head -c 32
       # ENCRYPTION_SALT must be a random string used as a salt for key derivation.
-      # Generate with: openssl rand -base64 32 | head -c 32
-      ENCRYPTION_KEY: "CHANGE_ME_32_CHARACTER_SECRET_K!"
-      ENCRYPTION_SALT: "CHANGE_ME_RANDOM_SALT_VALUE"
+      #   Generate with: openssl rand -base64 24
+      ENCRYPTION_KEY: ""
+      ENCRYPTION_SALT: ""
 
       # Draining configuration
       DRAINING_MODE: "archive"
@@ -100,7 +111,9 @@ services:
       # Workspace configuration
       DEFAULT_SNAPSHOT_IMAGE_NAME: "daytonaio/sandbox:0.5.1-slim"
       DEFAULT_SNAPSHOT_NAME: "default-snapshot"
-      RUNNER_MANAGER_API_KEY: "runner_manager_secret_key"
+      # REQUIRED: shared secret between the API and the runner manager.
+      # MUST match services.runnermanager.env.API_TOKEN. Generate with: openssl rand -hex 32
+      RUNNER_MANAGER_API_KEY: ""
       # Auto-generated as "https://{{.Values.baseDomain}}/dashboard" if not set or empty
       DASHBOARD_URL: ""
       # Auto-generated as "https://{{.Values.baseDomain}}" if not set or empty
@@ -303,7 +316,8 @@ services:
       PROXY_PORT: ""
       # Auto-generated as "proxy.{{.Values.baseDomain}}:{{PROXY_PORT}}" if not set or empty
       PROXY_DOMAIN: ""
-      PROXY_API_KEY: "super_secret_key"
+      # REQUIRED: no default is shipped. Generate with: openssl rand -hex 32
+      PROXY_API_KEY: ""
       PROXY_PROTOCOL: http
       OIDC_CLIENT_SECRET: ""
     # Extra environment variables (for valueFrom or additional custom vars)
@@ -378,13 +392,28 @@ services:
       type: LoadBalancer
       port: 2222
       annotations: {}
-    # Set api key for ssh gateway. This key is used to authenticate the ssh gateway against api
-    apiKey: supersecretapikey
-    # Generate ssh keys to be used for the ssh gateway. These keys are stored in the secret and used to authenticate the ssh gateway. Generate keys using ssh-keygen (ssh-keygen -t ed25519 -f gateway_host_key -N "") and store them as base64 (cat gateway_host_key | base64 -w 0) values here. You will need 2 groups of keys - one for the client and one for the gateway.
+    # REQUIRED: API key used to authenticate the SSH gateway against the API.
+    # No default is shipped. Generate with: openssl rand -hex 32
+    apiKey: ""
+    # SSH keys for the gateway. No keys are shipped with the chart; supply your own
+    # (a leaked/shared keypair lets anyone impersonate the gateway). Two keypairs are
+    # needed: one for the client, one for the gateway host.
+    #
+    # Generate and base64-encode:
+    #   ssh-keygen -t ed25519 -f client  -N "" -C client-key
+    #   ssh-keygen -t ed25519 -f gateway -N "" -C server-key
+    #   privClientSSHKey:  base64 -w0 client
+    #   pubClientSSHKey:   base64 -w0 client.pub
+    #   privGatewaySSHKey: base64 -w0 gateway
+    #
+    # Alternatively, point existingSecret at a pre-created Secret that contains keys
+    # SSH_PRIVATE_KEY, SSH_PRIVATE_PUB_KEY, SSH_HOST_KEY and API_KEY (e.g. managed by
+    # External Secrets / Sealed Secrets). When set, the chart does not template a Secret.
     sshKeys:
-      privClientSSHKey: "LS0tLS1CRUdJTiBPUEVOU1NIIFBSSVZBVEUgS0VZLS0tLS0KYjNCbGJuTnphQzFyWlhrdGRqRUFBQUFBQkc1dmJtVUFBQUFFYm05dVpRQUFBQUFBQUFBQkFBQUFNd0FBQUF0emMyZ3RaVwpReU5UVXhPUUFBQUNDK0FvVlE2TkhWUXJkUzA2V0lvMHAwamZWOXVQQUp0QUZMWGlBUlRIdC9lUUFBQUpEWmREVzMyWFExCnR3QUFBQXR6YzJndFpXUXlOVFV4T1FBQUFDQytBb1ZRNk5IVlFyZFMwNldJbzBwMGpmVjl1UEFKdEFGTFhpQVJUSHQvZVEKQUFBRUM2ZlVsOHlDdW1rQ3N3djF4N2tQQ0hSZS9iM242M3c0R3RCU3VScXpBblRiNENoVkRvMGRWQ3QxTFRwWWlqU25TTgo5WDI0OEFtMEFVdGVJQkZNZTM5NUFBQUFDbU5zYVdWdWRDMXJaWGtCQWdNPQotLS0tLUVORCBPUEVOU1NIIFBSSVZBVEUgS0VZLS0tLS0K"
-      pubClientSSHKey: "c3NoLWVkMjU1MTkgQUFBQUMzTnphQzFsWkRJMU5URTVBQUFBSUw0Q2hWRG8wZFZDdDFMVHBZaWpTblNOOVgyNDhBbTBBVXRlSUJGTWUzOTUgY2xpZW50LWtleQo="
-      privGatewaySSHKey: "LS0tLS1CRUdJTiBPUEVOU1NIIFBSSVZBVEUgS0VZLS0tLS0KYjNCbGJuTnphQzFyWlhrdGRqRUFBQUFBQkc1dmJtVUFBQUFFYm05dVpRQUFBQUFBQUFBQkFBQUFNd0FBQUF0emMyZ3RaVwpReU5UVXhPUUFBQUNETnFRUEczaTdJc3lndlNOcnFEWUtsVFluaUpMRTEwSExOaGFZTkZUY1ZGUUFBQUpDVVI2dERsRWVyClF3QUFBQXR6YzJndFpXUXlOVFV4T1FBQUFDRE5xUVBHM2k3SXN5Z3ZTTnJxRFlLbFRZbmlKTEUxMEhMTmhhWU5GVGNWRlEKQUFBRUNHRHR2RTA3Zk1HeWxkeVJmdHhiUEFzUlQ4VmppdjFZajVmL01vR2pMT0RNMnBBOGJlTHNpektDOUkydW9OZ3FWTgppZUlrc1RYUWNzMkZwZzBWTnhVVkFBQUFDbk5sY25abGNpMXJaWGtCQWdNPQotLS0tLUVORCBPUEVOU1NIIFBSSVZBVEUgS0VZLS0tLS0K"
+      existingSecret: ""
+      privClientSSHKey: ""
+      pubClientSSHKey: ""
+      privGatewaySSHKey: ""
     env:
       SSH_GATEWAY_PORT: "2222"
       # Auto-generated as "ssh.{{.Values.baseDomain}}" if not set or empty
@@ -436,10 +465,12 @@ services:
     env:
       # API Configuration
       API_PORT: "3010"
-      # API Authentication - Generate a secure token with: openssl rand -base64 32
-      API_TOKEN: "runner_manager_secret_key"
-      # System API Token
-      SYSTEM_API_TOKEN: "system_api_token"
+      # REQUIRED: API Authentication. MUST match services.api.env.RUNNER_MANAGER_API_KEY.
+      # Generate with: openssl rand -hex 32
+      API_TOKEN: ""
+      # REQUIRED: System API Token. MUST match services.runner.env.SYSTEM_API_TOKEN.
+      # Generate with: openssl rand -hex 32
+      SYSTEM_API_TOKEN: ""
       # Provider Configuration - Options: kubernetes, k8s, aws
       PROVIDER_TYPE: "kubernetes"
       # Kubernetes Provider - Namespace for placeholder pods (defaults to deployment namespace)
@@ -451,7 +482,8 @@ services:
       # Kubeconfig Path (Optional - for local development)
       # If not set, will use in-cluster configuration
       KUBECONFIG_PATH: ""
-      API_KEY: "secret_api_key"
+      # REQUIRED: no default is shipped. Generate with: openssl rand -hex 32
+      API_KEY: ""
       # Auto-generated as "https://{{.Values.baseDomain}}/api" if not set or empty
       SERVER_URL: "http://daytona-api:3000/api"
       REGION_ID: "us"
@@ -523,15 +555,19 @@ services:
       # Secrets
       DAYTONA_API_URL: "http://daytona-api:3000/api"
       SERVER_URL: "http://daytona-api:3000/api"
-      API_TOKEN: "secret_api_token"
-      SYSTEM_API_TOKEN: "system_api_token"
+      # REQUIRED: no default is shipped. Generate with: openssl rand -hex 32
+      API_TOKEN: ""
+      # REQUIRED: MUST match services.runnermanager.env.SYSTEM_API_TOKEN.
+      SYSTEM_API_TOKEN: ""
       AWS_REGION: ""
       AWS_ENDPOINT_URL: ""
       AWS_ACCESS_KEY_ID: ""
       AWS_SECRET_ACCESS_KEY: ""
       AWS_DEFAULT_BUCKET: ""
-      # The same value as the .Values.services.sshGateway.sshKeys.pubClientSSHKey
-      SSH_PUBLIC_KEY: "c3NoLWVkMjU1MTkgQUFBQUMzTnphQzFsWkRJMU5URTVBQUFBSUw0Q2hWRG8wZFZDdDFMVHBZaWpTblNOOVgyNDhBbTBBVXRlSUJGTWUzOTUgY2xpZW50LWtleQo="
+      # Authorized client public key the runner trusts for SSH gateway access.
+      # Leave empty to inherit services.sshGateway.sshKeys.pubClientSSHKey (recommended,
+      # keeps the keypair in one place). Set only to override.
+      SSH_PUBLIC_KEY: ""
     # Resource limits and requests
     resources:
       limits:
@@ -716,13 +752,15 @@ dex:
     # - http://localhost:3009/callback
     # - http://[fullname]-proxy:[proxy-port]/callback
     redirectURIs: []
-    # Static passwords (for development/testing)
-    # Password hash can be generated with: echo password | htpasswd -BinC 10 admin | cut -d: -f2
-    # default username/password is admin/password
+    # Static passwords (for development/testing only; use an upstream IdP in production).
+    # No password hash is shipped. The chart refuses to render until `password` is set to a
+    # bcrypt hash (security.validateSecrets), so there is no built-in admin/password account.
+    #   Generate a hash: htpasswd -BnC 10 "" <<< 'your-password' | tr -d ':\n'
+    # Set staticPasswords to [] if you disable Dex or drive all logins through an external IdP.
     staticPasswords:
-      - email: "dev@daytona.io"
+      - email: "admin@example.com"
         username: "admin"
-        password: "$2y$10$pQ8jbpk6RWHx/uYJtDey.uCTzVl2ZXg569tp63PE9uisbCYzoARW6"
+        password: ""   # REQUIRED: bcrypt hash. No plaintext default is shipped.
         userID: "1234"
 
 # API migration job configuration

--- a/charts/daytona/values.yaml
+++ b/charts/daytona/values.yaml
@@ -15,9 +15,11 @@ baseDomain: "daytona.example.com"
 # Security guardrails
 security:
   # Fail-closed secret validation. When true (default), the chart refuses to render if a
-  # security-sensitive secret is left empty or set to a value that was previously shipped as
-  # a default. Set to false ONLY if every required secret is delivered out-of-band (via
-  # existingSecret, the Secrets Store CSI Driver, or extraEnv secretKeyRef).
+  # security-sensitive secret is empty or set to a value the chart used to ship.
+  # Setting false skips validation of the env-delivered secrets (encryption key, API keys,
+  # tokens) for out-of-band delivery (extraEnv / Secrets Store CSI Driver). The SSH gateway
+  # keys and Dex password go into chart-managed resources and always fail closed regardless
+  # of this flag; for those use sshKeys.existingSecret and dex.config.staticPasswords: [].
   validateSecrets: true
 
 # Service-specific configurations


### PR DESCRIPTION
## What
The chart shipped working default credentials, an SSH keypair, and a built-in Dex admin in `values.yaml`. This removes them and makes installs fail closed until the operator supplies their own.

## Changes
- Blank all Daytona-owned secret defaults + SSH gateway keypairs in `values.yaml`; remove the Dex static admin.
- `security.validateSecrets` (default `true`): render aborts listing any secret left empty or at a shipped default. Set `false` to inject secrets out-of-band.
- `sshKeys.existingSecret` support (bring-your-own Secret) via a shared `daytona.sshSecretName` helper across all consumers; the runner inherits the gateway public key from the secret.
- Dex: no shipped hash; `enablePasswordDB` follows whether a static user is configured.
- `NOTES.txt`: stop printing a default password; handle the no-static-user case.
- README: add a "Required secrets" section and upgrade/rotation guidance.
- Chart `0.1.0`. **Breaking:** a stock `helm install` no longer renders without operator-set secrets.

## Validation
`helm lint` clean. `helm template` verified across stock (fails closed with a list of missing secrets), fully configured, `existingSecret`, and out-of-band (`validateSecrets=false`) paths; no shipped secret value remains in rendered output.

## Upgrade note
Existing deployments must set the new values and rotate any previously shipped secrets and SSH keys before upgrading (the old values are in public chart history).

> Note: this branch is cut from `main` (chart `0.0.25`); the registry currently has `0.0.26`. Please confirm `0.0.26` content is preserved on rebase (`0.1.0` sorts above it). Bundled-datastore passwords (PostgreSQL/Harbor/pgAdmin) are intentionally out of scope here and tracked as a follow-up.
