### PR TITLE
feat: allow configuring annotations on the Dex Service

### DIFF
--- a/charts/daytona/templates/dex-service.yaml
+++ b/charts/daytona/templates/dex-service.yaml
@@ -7,6 +7,10 @@ metadata:
   labels:
     {{- include "daytona.labels" . | nindent 4 }}
     app.kubernetes.io/component: dex
+  {{- with .Values.dex.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   type: ClusterIP
   ports:

--- a/charts/daytona/values.yaml
+++ b/charts/daytona/values.yaml
@@ -650,6 +650,8 @@ dex:
       pullPolicy: IfNotPresent
   service:
     port: 5556
+    annotations: {}
+      #cloud.google.com/backend-config: '{"default":"daytona-dex-backendconfig"}'
   persistence:
     enabled: true
     size: 1Gi


### PR DESCRIPTION
## Summary

This change adds support for configuring custom annotations on the Dex Service through Helm values.

## Changes

- Added support for `dex.service.annotations` in the Dex Service template.
- Annotations are rendered only when configured, preserving the existing behavior by default.

## Motivation

Some environments require Service annotations for integrations such as:
- Cloud load balancers
- Service meshes
- External DNS
- Monitoring or networking controllers

This change enables those use cases without requiring users to fork or patch the Helm chart.

## Example

values.yaml

dex:
  service:
    annotations:
      cloud.google.com/backend-config: '{"default":"daytona-dex-backendconfig"}'