### PR TITLE
fix(daytona-region): pin prod-lineage runner-manager and v0.201 runner image

### DIFF
--- a/charts/daytona-region/Chart.yaml
+++ b/charts/daytona-region/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: daytona-region
 description: A Helm chart for Daytona custom region
 type: application
-version: 0.1.0
+version: 0.1.1
 appVersion: "v0.183.0"
 keywords:
   - ai

--- a/charts/daytona-region/README.md
+++ b/charts/daytona-region/README.md
@@ -590,6 +590,10 @@ Snapshot-manager log shows `panic ... nil pointer` in `s3-aws.(*driver).Writer` 
 
 Not every chart `appVersion` has a matching `daytonaio/daytona-runner-manager` tag on Docker Hub. Keep the chart's pinned default tag, or verify the tag exists before overriding `services.runnermanager.image.tag`.
 
+### New runners never register / runner-manager loops every 20s
+
+Check whether `services.runnermanager.image.tag` is overridden. Runner-manager tags are not interchangeable — a tag other than the chart's pinned default (including `*-byoc` / `*-k8s-oss` tags, regardless of version number) is incompatible with the chart's runner image, so every registration fails and the autoscaler loop retries forever. Remove the override so the chart's pinned tag applies.
+
 ### ECR snapshot creation fails with `no basic auth credentials`
 
 The runner's `INSPECT_SNAPSHOT_IN_REGISTRY` job is not the right layer to look at — it has no ECR-auth code path of its own. Credentials are obtained centrally by the Daytona API via `sts:AssumeRole` into a role you register, and handed to the runner per-job. If that flow breaks, the runner has nothing to fall back on and the inspect call goes anonymous.

--- a/charts/daytona-region/templates/runner-manager-deployment.yaml
+++ b/charts/daytona-region/templates/runner-manager-deployment.yaml
@@ -61,6 +61,14 @@ spec:
                 secretKeyRef:
                   name: {{ include "daytona.runnermanagerDaytonaApiSecretName" . }}
                   key: {{ include "daytona.runnermanagerDaytonaApiSecretKey" . }}
+            # Required (but unused) by the v0.174.0 runner-manager's config
+            # validation — without it the manager exits at boot. Same secret as
+            # API_TOKEN.
+            - name: SYSTEM_API_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "daytona.runnermanagerDaytonaApiSecretName" . }}
+                  key: {{ include "daytona.runnermanagerDaytonaApiSecretKey" . }}
             - name: PROVIDER_TYPE
               value: {{ .Values.services.runnermanager.env.PROVIDER_TYPE | default "kubernetes" | quote }}
             - name: PROVIDER_NAMESPACE

--- a/charts/daytona-region/values.yaml
+++ b/charts/daytona-region/values.yaml
@@ -350,9 +350,12 @@ services:
     image:
       registry: docker.io
       repository: daytonaio/daytona-runner-manager
-      # NOTE: keep a tag that exists on Docker Hub for this BYOC fork lineage.
-      # v0.183.0 has no published daytona-runner-manager image (ImagePullBackOff).
-      tag: "v0.158.4-4-byoc-amd64"
+      # NOTE: keep the chart's pinned tag. Runner-manager tags on Docker Hub are
+      # not interchangeable and are not comparable by version number alone —
+      # only the tag pinned here is validated against this chart's runner image.
+      # Overriding it (e.g. with a *-byoc or *-k8s-oss tag) breaks registration
+      # of new runners.
+      tag: "v0.174.0-amd64"
       pullPolicy: IfNotPresent
     service:
       type: ClusterIP
@@ -469,7 +472,10 @@ services:
     image:
       registry: docker.io
       repository: daytonaio/daytona-runner
-      tag: ""
+      # Also the default RUNNER_POD_IMAGE the runner-manager spawns (amd64-only
+      # tag). Empty falls back to appVersion (v0.183.0), which is also
+      # compatible with the pinned runner-manager.
+      tag: "v0.201.0-b24aa9b-amd64"
       pullPolicy: IfNotPresent
     # mainContainer: opt-in K8s-native runner container that runs `daytona-runner` as a
     # privileged container inside the DaemonSet pod (sibling to the host-bootstrap

--- a/docs/README.md
+++ b/docs/README.md
@@ -90,6 +90,10 @@ Chart-side runner hardening and operations knobs are collected in
 [`operations.md`](operations.md). The cloud values templates opt into the
 security defaults where appropriate.
 
+The supported upgrade process and the blessed per-component version matrix are
+in [`upgrades.md`](upgrades.md) — component versions are intentionally not in
+lockstep; upgrade via the chart, not by overriding image tags.
+
 | Improvement | Values key(s) | Doc |
 |---|---|---|
 | Stale runner cleanup | `services.runnerReaper` | [`operations.md`](operations.md#runner-reaper) |

--- a/docs/upgrades.md
+++ b/docs/upgrades.md
@@ -1,0 +1,60 @@
+# Daytona BYOC Upgrades
+
+This is the supported upgrade process for BYOC regions deployed with the
+`daytona-region` chart. Components are versioned independently — **do not
+expect flat version parity** across runner, runner-manager, proxy,
+snapshot-manager, and ssh-gateway. The chart's pinned defaults are the blessed
+combination; upgrade by upgrading the chart, not by overriding individual image
+tags.
+
+## Blessed version matrix (chart 0.1.1)
+
+| Component | Image | Version |
+|---|---|---|
+| Runner | `daytonaio/daytona-runner` | `v0.201.0-b24aa9b-amd64` |
+| Runner manager | `daytonaio/daytona-runner-manager` | `v0.174.0-amd64` |
+| Proxy | `daytonaio/daytona-proxy` | chart `appVersion` (`v0.183.0`) |
+| Snapshot manager | `daytonaio/daytona-snapshot-manager` | chart `appVersion` (`v0.183.0`) |
+| SSH gateway | `daytonaio/daytona-ssh-gateway` | chart `appVersion` (`v0.183.0`) |
+
+Do not select image tags from Docker Hub by version number — tags are not
+comparable across components, and some published runner-manager tags (e.g.
+`*-byoc`, `*-k8s-oss`) are not compatible with this chart's runner image even
+though their version numbers are higher. The matrix above is the only
+supported combination; pairing anything else can break registration of new
+runners.
+
+## Upgrading the chart
+
+```bash
+helm repo update
+helm upgrade <release> daytona/daytona-region -n <namespace> -f your-values.yaml
+```
+
+If you override image tags in your values, remove the overrides so the chart's
+pinned defaults apply.
+
+## Rolling runners to a new image
+
+Upgrading the chart changes the image used for **new** runner pods; existing
+runners keep running the old image until rolled. To roll without disrupting
+sandboxes:
+
+1. Scale up: create new runners on the new version (raise `MIN_RUNNERS`, or
+   `POST /runners/add` on the runner-manager API).
+2. Mark the old runners unschedulable — this drains them and starts sandboxes
+   on the new runners.
+3. Wait and verify no sandboxes remain on the old runners.
+4. Delete the old runners.
+5. Restore `MIN_RUNNERS` if you raised it.
+
+## Checking what you are running
+
+The image tag in your cluster is not authoritative for the runner version — the
+runner reports its build version to Daytona Cloud. Ask Daytona support to
+confirm the reported `appVersion` of your runners, or compare your deployed
+tags against the matrix above:
+
+```bash
+kubectl get pods -n <namespace> -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.spec.containers[0].image}{"\n"}{end}'
+```


### PR DESCRIPTION
### Problem
The chart pins `daytona-runner-manager:v0.158.4-4-byoc-amd64` (fork lineage), which configures new runners via the runner's `/system/config` endpoint. Prod-built runner images (`v0.183.0`+) don't have that endpoint, so with that pairing every new runner fails to register. Working BYOC deployments actually run the `v0.174.0` manager — a plain `helm upgrade` today would swap the broken fork manager back in.

### Changes
  - runner-manager pin → `v0.174.0-amd64` (org-scoped `/runners` registration, env-based runner config — works with prod runner images)
  - runner pin → `v0.201.0-b24aa9b-amd64` (also the `RUNNER_POD_IMAGE` default)
  - render `SYSTEM_API_TOKEN` in the manager deployment (v0.174.0 requires it at boot)
  - new `docs/upgrades.md`: version matrix + upgrade/runner-roll procedure
  - chart `0.1.0 → 0.1.1`; `appVersion` intentionally unchanged (no v0.201 images for proxy/snapshot-manager/ssh-gateway)
