### PR TITLE
Chore/bump v0.207.0

### DIFF
--- a/charts/daytona-region/Chart.yaml
+++ b/charts/daytona-region/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: daytona-region
 description: A Helm chart for Daytona custom region
 type: application
-version: 0.1.1
-appVersion: "v0.183.0"
+version: 0.2.0
+appVersion: "v0.207.0"
 keywords:
   - ai
   - infrastructure

--- a/charts/daytona-region/values.yaml
+++ b/charts/daytona-region/values.yaml
@@ -472,10 +472,9 @@ services:
     image:
       registry: docker.io
       repository: daytonaio/daytona-runner
-      # Also the default RUNNER_POD_IMAGE the runner-manager spawns (amd64-only
-      # tag). Empty falls back to appVersion (v0.183.0), which is also
-      # compatible with the pinned runner-manager.
-      tag: "v0.201.0-b24aa9b-amd64"
+      # Also the default RUNNER_POD_IMAGE the runner-manager spawns.
+      # Empty falls back to the chart appVersion.
+      tag: ""
       pullPolicy: IfNotPresent
     # mainContainer: opt-in K8s-native runner container that runs `daytona-runner` as a
     # privileged container inside the DaemonSet pod (sibling to the host-bootstrap

--- a/docs/upgrades.md
+++ b/docs/upgrades.md
@@ -7,15 +7,15 @@ snapshot-manager, and ssh-gateway. The chart's pinned defaults are the blessed
 combination; upgrade by upgrading the chart, not by overriding individual image
 tags.
 
-## Blessed version matrix (chart 0.1.1)
+## Blessed version matrix (chart 0.2.0)
 
 | Component | Image | Version |
 |---|---|---|
-| Runner | `daytonaio/daytona-runner` | `v0.201.0-b24aa9b-amd64` |
+| Runner | `daytonaio/daytona-runner` | chart `appVersion` (`v0.207.0`) |
 | Runner manager | `daytonaio/daytona-runner-manager` | `v0.174.0-amd64` |
-| Proxy | `daytonaio/daytona-proxy` | chart `appVersion` (`v0.183.0`) |
-| Snapshot manager | `daytonaio/daytona-snapshot-manager` | chart `appVersion` (`v0.183.0`) |
-| SSH gateway | `daytonaio/daytona-ssh-gateway` | chart `appVersion` (`v0.183.0`) |
+| Proxy | `daytonaio/daytona-proxy` | chart `appVersion` (`v0.207.0`) |
+| Snapshot manager | `daytonaio/daytona-snapshot-manager` | chart `appVersion` (`v0.207.0`) |
+| SSH gateway | `daytonaio/daytona-ssh-gateway` | chart `appVersion` (`v0.207.0`) |
 
 Do not select image tags from Docker Hub by version number — tags are not
 comparable across components, and some published runner-manager tags (e.g.


### PR DESCRIPTION
### What
  - `appVersion` `v0.183.0` → `v0.207.0`: proxy, snapshot-manager, ssh-gateway, and runner now default to the new multi-arch `v0.207.0` images
  published on Docker Hub.
  - Drop the interim `v0.201.0-b24aa9b-amd64` runner pin — the runner falls back to `appVersion` like the other components.
  - Runner-manager stays pinned to `v0.174.0-amd64` (intentional; see `docs/upgrades.md`).
  - Version matrix in `docs/upgrades.md` updated; chart `0.1.1` → `0.2.0`.

### Compatibility
  - No component gained new required configuration between v0.183.0 and v0.207.0 (all additions are optional with safe defaults); required env sets are
  unchanged, so existing values files keep working.
  - Runner v0.207.0 is config-compatible with the pinned v0.174.0 runner-manager.
  - This combination matches what Daytona runs in production.