### PR TITLE
fix(daytona-region): restore v0.158.4-4-byoc runner-manager pin

### DIFF
--- a/charts/daytona-region/Chart.yaml
+++ b/charts/daytona-region/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: daytona-region
 description: A Helm chart for Daytona custom region
 type: application
-version: 0.2.0
+version: 0.2.1
 appVersion: "v0.207.0"
 keywords:
   - ai

--- a/charts/daytona-region/README.md
+++ b/charts/daytona-region/README.md
@@ -592,7 +592,7 @@ Not every chart `appVersion` has a matching `daytonaio/daytona-runner-manager` t
 
 ### New runners never register / runner-manager loops every 20s
 
-Check whether `services.runnermanager.image.tag` is overridden. Runner-manager tags are not interchangeable — a tag other than the chart's pinned default (including `*-byoc` / `*-k8s-oss` tags, regardless of version number) is incompatible with the chart's runner image, so every registration fails and the autoscaler loop retries forever. Remove the override so the chart's pinned tag applies.
+Check whether `services.runnermanager.image.tag` is overridden. Runner-manager tags are not interchangeable — a tag other than the chart's pinned default is not validated against this chart's runner image, regardless of version number — `v0.174.0`, for example, is an older, incomplete build that only creates placeholder pods and never launches a runner. Remove the override so the chart's pinned tag applies.
 
 ### ECR snapshot creation fails with `no basic auth credentials`
 

--- a/charts/daytona-region/templates/runner-manager-deployment.yaml
+++ b/charts/daytona-region/templates/runner-manager-deployment.yaml
@@ -61,9 +61,8 @@ spec:
                 secretKeyRef:
                   name: {{ include "daytona.runnermanagerDaytonaApiSecretName" . }}
                   key: {{ include "daytona.runnermanagerDaytonaApiSecretKey" . }}
-            # Required (but unused) by the v0.174.0 runner-manager's config
-            # validation — without it the manager exits at boot. Same secret as
-            # API_TOKEN.
+            # Required by the runner-manager's config validation — without it the
+            # manager exits at boot. Same secret as API_TOKEN.
             - name: SYSTEM_API_TOKEN
               valueFrom:
                 secretKeyRef:

--- a/charts/daytona-region/values.yaml
+++ b/charts/daytona-region/values.yaml
@@ -351,11 +351,11 @@ services:
       registry: docker.io
       repository: daytonaio/daytona-runner-manager
       # NOTE: keep the chart's pinned tag. Runner-manager tags on Docker Hub are
-      # not interchangeable and are not comparable by version number alone —
+      # NOT comparable by version number — they come from different builds, and
       # only the tag pinned here is validated against this chart's runner image.
-      # Overriding it (e.g. with a *-byoc or *-k8s-oss tag) breaks registration
-      # of new runners.
-      tag: "v0.174.0-amd64"
+      # In particular v0.174.0 is an older, incomplete build despite the higher
+      # number: it only creates placeholder pods and never launches a runner.
+      tag: "v0.158.4-4-byoc-amd64"
       pullPolicy: IfNotPresent
     service:
       type: ClusterIP

--- a/docs/upgrades.md
+++ b/docs/upgrades.md
@@ -7,20 +7,21 @@ snapshot-manager, and ssh-gateway. The chart's pinned defaults are the blessed
 combination; upgrade by upgrading the chart, not by overriding individual image
 tags.
 
-## Blessed version matrix (chart 0.2.0)
+## Blessed version matrix (chart 0.2.1)
 
 | Component | Image | Version |
 |---|---|---|
 | Runner | `daytonaio/daytona-runner` | chart `appVersion` (`v0.207.0`) |
-| Runner manager | `daytonaio/daytona-runner-manager` | `v0.174.0-amd64` |
+| Runner manager | `daytonaio/daytona-runner-manager` | `v0.158.4-4-byoc-amd64` |
 | Proxy | `daytonaio/daytona-proxy` | chart `appVersion` (`v0.207.0`) |
 | Snapshot manager | `daytonaio/daytona-snapshot-manager` | chart `appVersion` (`v0.207.0`) |
 | SSH gateway | `daytonaio/daytona-ssh-gateway` | chart `appVersion` (`v0.207.0`) |
 
 Do not select image tags from Docker Hub by version number — tags are not
-comparable across components, and some published runner-manager tags (e.g.
-`*-byoc`, `*-k8s-oss`) are not compatible with this chart's runner image even
-though their version numbers are higher. The matrix above is the only
+comparable across components, and runner-manager tags are not comparable to
+each other either. Some published runner-manager tags with higher version
+numbers (e.g. `v0.174.0`) are older or incomplete builds that never launch a
+runner. The matrix above is the only
 supported combination; pairing anything else can break registration of new
 runners.
 


### PR DESCRIPTION
### Problem
#35 repinned the runner-manager to `v0.174.0-amd64` assuming a higher version meant a newer build. It doesn't — that tag is an older, incomplete build that only creates placeholder pods and never launches a runner, so a region can't bootstrap with it.

### Changes
  - Restore `v0.158.4-4-byoc-amd64` — the build working BYOC regions run today (org-scoped `/runners` registration, launches runner pods from `RUNNER_POD_IMAGE`).
  - Correct tag guidance in values, README, and `docs/upgrades.md`: runner-manager tags aren't comparable by version number.
  - Keep `SYSTEM_API_TOKEN` from #35 — this image requires it at boot.
  - Chart `0.2.0 → 0.2.1`; `appVersion` (v0.207.0) unchanged.

Runner v0.207.0 works with this manager — runner pods are configured purely via env, and that contract is unchanged from v0.183 to v0.207.