### PR TITLE
chore(daytona-region): default runner-manager to appVersion image

### DIFF
--- a/charts/daytona-region/Chart.yaml
+++ b/charts/daytona-region/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: daytona-region
 description: A Helm chart for Daytona custom region
 type: application
-version: 0.2.1
+version: 0.2.2
 appVersion: "v0.207.0"
 keywords:
   - ai

--- a/charts/daytona-region/tests/baselines/rendered-baseline.yaml
+++ b/charts/daytona-region/tests/baselines/rendered-baseline.yaml
@@ -6,10 +6,10 @@ metadata:
   name: release-name-daytona-region-proxy
   namespace: default
   labels:
-    helm.sh/chart: daytona-region-0.1.0
+    helm.sh/chart: daytona-region-0.2.2
     app.kubernetes.io/name: daytona-region
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "v0.183.0"
+    app.kubernetes.io/version: "v0.207.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: proxy
 
@@ -21,10 +21,10 @@ metadata:
   name: release-name-daytona-region-runnermanager
   namespace: default
   labels:
-    helm.sh/chart: daytona-region-0.1.0
+    helm.sh/chart: daytona-region-0.2.2
     app.kubernetes.io/name: daytona-region
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "v0.183.0"
+    app.kubernetes.io/version: "v0.207.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: runnermanager
 
@@ -36,10 +36,10 @@ metadata:
   name: release-name-daytona-region-runner
   namespace: default
   labels:
-    helm.sh/chart: daytona-region-0.1.0
+    helm.sh/chart: daytona-region-0.2.2
     app.kubernetes.io/name: daytona-region
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "v0.183.0"
+    app.kubernetes.io/version: "v0.207.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: runner
 
@@ -51,10 +51,10 @@ metadata:
   name: release-name-daytona-region-ssh-gateway
   namespace: default
   labels:
-    helm.sh/chart: daytona-region-0.1.0
+    helm.sh/chart: daytona-region-0.2.2
     app.kubernetes.io/name: daytona-region
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "v0.183.0"
+    app.kubernetes.io/version: "v0.207.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: ssh-gateway
 
@@ -66,10 +66,10 @@ metadata:
   name: release-name-daytona-region-runner-secrets
   namespace: default
   labels:
-    helm.sh/chart: daytona-region-0.1.0
+    helm.sh/chart: daytona-region-0.2.2
     app.kubernetes.io/name: daytona-region
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "v0.183.0"
+    app.kubernetes.io/version: "v0.207.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: runner
 type: Opaque
@@ -92,10 +92,10 @@ metadata:
   name: release-name-daytona-region-secret-ssh
   namespace: default
   labels:
-    helm.sh/chart: daytona-region-0.1.0
+    helm.sh/chart: daytona-region-0.2.2
     app.kubernetes.io/name: daytona-region
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "v0.183.0"
+    app.kubernetes.io/version: "v0.207.0"
     app.kubernetes.io/managed-by: Helm
 type: Opaque
 data:
@@ -112,10 +112,10 @@ metadata:
   name: release-name-daytona-region-runner-config
   namespace: default
   labels:
-    helm.sh/chart: daytona-region-0.1.0
+    helm.sh/chart: daytona-region-0.2.2
     app.kubernetes.io/name: daytona-region
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "v0.183.0"
+    app.kubernetes.io/version: "v0.207.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: runner
 data:
@@ -146,10 +146,10 @@ metadata:
   name: release-name-daytona-region-runner-docker-installer-config
   namespace: default
   labels:
-    helm.sh/chart: daytona-region-0.1.0
+    helm.sh/chart: daytona-region-0.2.2
     app.kubernetes.io/name: daytona-region
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "v0.183.0"
+    app.kubernetes.io/version: "v0.207.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: runner
 data:
@@ -163,10 +163,10 @@ kind: ClusterRole
 metadata:
   name: release-name-daytona-region-runner-manager-nodes
   labels:
-    helm.sh/chart: daytona-region-0.1.0
+    helm.sh/chart: daytona-region-0.2.2
     app.kubernetes.io/name: daytona-region
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "v0.183.0"
+    app.kubernetes.io/version: "v0.207.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: runnermanager
 rules:
@@ -181,10 +181,10 @@ kind: ClusterRoleBinding
 metadata:
   name: release-name-daytona-region-runner-manager-nodes
   labels:
-    helm.sh/chart: daytona-region-0.1.0
+    helm.sh/chart: daytona-region-0.2.2
     app.kubernetes.io/name: daytona-region
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "v0.183.0"
+    app.kubernetes.io/version: "v0.207.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: runnermanager
 roleRef:
@@ -204,10 +204,10 @@ metadata:
   name: release-name-daytona-region-runnermanager
   namespace: default
   labels:
-    helm.sh/chart: daytona-region-0.1.0
+    helm.sh/chart: daytona-region-0.2.2
     app.kubernetes.io/name: daytona-region
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "v0.183.0"
+    app.kubernetes.io/version: "v0.207.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: runnermanager
 rules:
@@ -229,10 +229,10 @@ metadata:
   name: release-name-daytona-region-runnermanager
   namespace: default
   labels:
-    helm.sh/chart: daytona-region-0.1.0
+    helm.sh/chart: daytona-region-0.2.2
     app.kubernetes.io/name: daytona-region
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "v0.183.0"
+    app.kubernetes.io/version: "v0.207.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: runnermanager
 roleRef:
@@ -252,10 +252,10 @@ metadata:
   namespace: default
   name: release-name-daytona-region-proxy
   labels:
-    helm.sh/chart: daytona-region-0.1.0
+    helm.sh/chart: daytona-region-0.2.2
     app.kubernetes.io/name: daytona-region
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "v0.183.0"
+    app.kubernetes.io/version: "v0.207.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: proxy
 spec:
@@ -278,10 +278,10 @@ metadata:
   name: release-name-daytona-region-runnermanager
   namespace: default
   labels:
-    helm.sh/chart: daytona-region-0.1.0
+    helm.sh/chart: daytona-region-0.2.2
     app.kubernetes.io/name: daytona-region
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "v0.183.0"
+    app.kubernetes.io/version: "v0.207.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: runnermanager
 spec:
@@ -304,10 +304,10 @@ metadata:
   name: release-name-daytona-region-ssh-gateway
   namespace: default
   labels:
-    helm.sh/chart: daytona-region-0.1.0
+    helm.sh/chart: daytona-region-0.2.2
     app.kubernetes.io/name: daytona-region
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "v0.183.0"
+    app.kubernetes.io/version: "v0.207.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: ssh-gateway
 spec:
@@ -330,10 +330,10 @@ metadata:
   name: release-name-daytona-region-runner
   namespace: default
   labels:
-    helm.sh/chart: daytona-region-0.1.0
+    helm.sh/chart: daytona-region-0.2.2
     app.kubernetes.io/name: daytona-region
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "v0.183.0"
+    app.kubernetes.io/version: "v0.207.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: runner
 spec:
@@ -794,7 +794,7 @@ spec:
         #   path on the host via the host-root bind-mount. Stale empty
         #   directories auto-created by Docker are cleaned up first.
         - name: daytona-binary-installer
-          image: "docker.io/daytonaio/daytona-runner:v0.183.0"
+          image: "docker.io/daytonaio/daytona-runner:v0.207.0"
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -943,10 +943,10 @@ metadata:
   namespace: default
   name: release-name-daytona-region-proxy
   labels:
-    helm.sh/chart: daytona-region-0.1.0
+    helm.sh/chart: daytona-region-0.2.2
     app.kubernetes.io/name: daytona-region
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "v0.183.0"
+    app.kubernetes.io/version: "v0.207.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: proxy
 spec:
@@ -975,7 +975,7 @@ spec:
             readOnlyRootFilesystem: false
             runAsNonRoot: false
             runAsUser: 0
-          image: "docker.io/daytonaio/daytona-proxy:v0.183.0"
+          image: "docker.io/daytonaio/daytona-proxy:v0.207.0"
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -1018,10 +1018,10 @@ metadata:
   namespace: default
   name: release-name-daytona-region-runnermanager
   labels:
-    helm.sh/chart: daytona-region-0.1.0
+    helm.sh/chart: daytona-region-0.2.2
     app.kubernetes.io/name: daytona-region
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "v0.183.0"
+    app.kubernetes.io/version: "v0.207.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: runnermanager
 spec:
@@ -1052,7 +1052,7 @@ spec:
             readOnlyRootFilesystem: false
             runAsNonRoot: false
             runAsUser: 0
-          image: "docker.io/daytonaio/daytona-runner-manager:v0.158.4-4-byoc-amd64"
+          image: "docker.io/daytonaio/daytona-runner-manager:v0.207.0"
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -1069,6 +1069,13 @@ spec:
               value: "2"
             # Daytona org API key (Bearer) — same value as daytonaApiKey / registration hook secret
             - name: API_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: release-name-daytona-region-daytona-api-key
+                  key: daytona-api-key
+            # Required by the runner-manager's config validation — without it the
+            # manager exits at boot. Same secret as API_TOKEN.
+            - name: SYSTEM_API_TOKEN
               valueFrom:
                 secretKeyRef:
                   name: release-name-daytona-region-daytona-api-key
@@ -1095,7 +1102,7 @@ spec:
             - name: PLACEHOLDER_POD_IMAGE
               value: "registry.k8s.io/pause:3.6"
             - name: RUNNER_POD_IMAGE
-              value: "docker.io/daytonaio/daytona-runner:v0.183.0"
+              value: "docker.io/daytonaio/daytona-runner:v0.207.0"
             - name: RUNNER_POD_SERVICE_ACCOUNT
               value: "release-name-daytona-region-runner"
             - name: RUNNER_POD_CONFIG_MAP
@@ -1130,10 +1137,10 @@ metadata:
   name: release-name-daytona-region-ssh-gateway
   namespace: default
   labels:
-    helm.sh/chart: daytona-region-0.1.0
+    helm.sh/chart: daytona-region-0.2.2
     app.kubernetes.io/name: daytona-region
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "v0.183.0"
+    app.kubernetes.io/version: "v0.207.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: ssh-gateway
 spec:
@@ -1162,7 +1169,7 @@ spec:
             readOnlyRootFilesystem: false
             runAsNonRoot: false
             runAsUser: 0
-          image: "docker.io/daytonaio/daytona-ssh-gateway:v0.183.0"
+          image: "docker.io/daytonaio/daytona-ssh-gateway:v0.207.0"
           imagePullPolicy: IfNotPresent
           ports:
             - name: ssh
@@ -1194,10 +1201,10 @@ metadata:
   name: release-name-daytona-region-proxy
   namespace: default
   labels:
-    helm.sh/chart: daytona-region-0.1.0
+    helm.sh/chart: daytona-region-0.2.2
     app.kubernetes.io/name: daytona-region
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "v0.183.0"
+    app.kubernetes.io/version: "v0.207.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: proxy
   annotations:
@@ -1241,16 +1248,17 @@ metadata:
   name: release-name-daytona-region-region-registration
   namespace: default
   labels:
-    helm.sh/chart: daytona-region-0.1.0
+    helm.sh/chart: daytona-region-0.2.2
     app.kubernetes.io/name: daytona-region
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "v0.183.0"
+    app.kubernetes.io/version: "v0.207.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: region-registration
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-weight": "-10"
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+
 ---
 # Source: daytona-region/templates/region-registration-hook.yaml
 apiVersion: v1
@@ -1259,10 +1267,10 @@ metadata:
   name: release-name-daytona-region-daytona-api-key
   namespace: default
   labels:
-    helm.sh/chart: daytona-region-0.1.0
+    helm.sh/chart: daytona-region-0.2.2
     app.kubernetes.io/name: daytona-region
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "v0.183.0"
+    app.kubernetes.io/version: "v0.207.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: region-registration
   annotations:
@@ -1283,10 +1291,10 @@ metadata:
   name: release-name-daytona-region-region-registration
   namespace: default
   labels:
-    helm.sh/chart: daytona-region-0.1.0
+    helm.sh/chart: daytona-region-0.2.2
     app.kubernetes.io/name: daytona-region
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "v0.183.0"
+    app.kubernetes.io/version: "v0.207.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: region-registration
   annotations:
@@ -1297,6 +1305,7 @@ rules:
   - apiGroups: [""]
     resources: ["secrets"]
     verbs: ["create", "update", "patch", "get"]
+
 ---
 # Source: daytona-region/templates/region-registration-rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -1305,10 +1314,10 @@ metadata:
   name: release-name-daytona-region-region-registration
   namespace: default
   labels:
-    helm.sh/chart: daytona-region-0.1.0
+    helm.sh/chart: daytona-region-0.2.2
     app.kubernetes.io/name: daytona-region
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "v0.183.0"
+    app.kubernetes.io/version: "v0.207.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: region-registration
   annotations:
@@ -1332,10 +1341,10 @@ metadata:
   name: release-name-daytona-region-region-registration
   namespace: default
   labels:
-    helm.sh/chart: daytona-region-0.1.0
+    helm.sh/chart: daytona-region-0.2.2
     app.kubernetes.io/name: daytona-region
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "v0.183.0"
+    app.kubernetes.io/version: "v0.207.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: region-registration
   annotations:
@@ -1381,10 +1390,10 @@ spec:
                 name: release-name-daytona-region-region-config
                 namespace: default
                 labels:
-                  helm.sh/chart: daytona-region-0.1.0
+                  helm.sh/chart: daytona-region-0.2.2
                   app.kubernetes.io/name: daytona-region
                   app.kubernetes.io/instance: release-name
-                  app.kubernetes.io/version: "v0.183.0"
+                  app.kubernetes.io/version: "v0.207.0"
                   app.kubernetes.io/managed-by: Helm
                   app.kubernetes.io/component: region-config
               type: Opaque
@@ -1530,3 +1539,4 @@ spec:
             requests:
               cpu: 50m
               memory: 64Mi
+

--- a/charts/daytona-region/values.yaml
+++ b/charts/daytona-region/values.yaml
@@ -350,12 +350,12 @@ services:
     image:
       registry: docker.io
       repository: daytonaio/daytona-runner-manager
-      # NOTE: keep the chart's pinned tag. Runner-manager tags on Docker Hub are
-      # NOT comparable by version number — they come from different builds, and
-      # only the tag pinned here is validated against this chart's runner image.
-      # In particular v0.174.0 is an older, incomplete build despite the higher
-      # number: it only creates placeholder pods and never launches a runner.
-      tag: "v0.158.4-4-byoc-amd64"
+      # Empty falls back to the chart appVersion, like the other components.
+      # NOTE: do not override with another Docker Hub tag — runner-manager tags
+      # come from different builds and are NOT comparable by version number
+      # (v0.174.0, for example, only creates placeholder pods and never
+      # launches a runner). The appVersion image is amd64-only.
+      tag: ""
       pullPolicy: IfNotPresent
     service:
       type: ClusterIP

--- a/docs/upgrades.md
+++ b/docs/upgrades.md
@@ -7,12 +7,12 @@ snapshot-manager, and ssh-gateway. The chart's pinned defaults are the blessed
 combination; upgrade by upgrading the chart, not by overriding individual image
 tags.
 
-## Blessed version matrix (chart 0.2.1)
+## Blessed version matrix (chart 0.2.2)
 
 | Component | Image | Version |
 |---|---|---|
 | Runner | `daytonaio/daytona-runner` | chart `appVersion` (`v0.207.0`) |
-| Runner manager | `daytonaio/daytona-runner-manager` | `v0.158.4-4-byoc-amd64` |
+| Runner manager | `daytonaio/daytona-runner-manager` | chart `appVersion` (`v0.207.0`, amd64-only) |
 | Proxy | `daytonaio/daytona-proxy` | chart `appVersion` (`v0.207.0`) |
 | Snapshot manager | `daytonaio/daytona-snapshot-manager` | chart `appVersion` (`v0.207.0`) |
 | SSH gateway | `daytonaio/daytona-ssh-gateway` | chart `appVersion` (`v0.207.0`) |


### PR DESCRIPTION
### Changes
  - `services.runnermanager.image.tag: ""` — the runner-manager now follows the chart `appVersion` like
  every other component. `daytonaio/daytona-runner-manager:v0.207.0` is the same working build previously
  published as `v0.158.4-4-byoc-amd64`, retagged so all five components line up on one version.
  - Regenerated `tests/baselines/rendered-baseline.yaml` — it was stale from chart 0.1.0 / v0.183.0 and
  the gate doesn't filter `app.kubernetes.io/version`, so it has been failing since #36.
  - Chart `0.2.1 → 0.2.2`; `appVersion` (v0.207.0) unchanged.