### PR TITLE
feat(daytona-region): deny inter-sandbox traffic on the default bridge

### DIFF
--- a/charts/daytona-region/Chart.yaml
+++ b/charts/daytona-region/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: daytona-region
 description: A Helm chart for Daytona custom region
 type: application
-version: 0.2.2
+version: 0.2.3
 appVersion: "v0.207.0"
 keywords:
   - ai

--- a/charts/daytona-region/templates/NOTES.txt
+++ b/charts/daytona-region/templates/NOTES.txt
@@ -85,9 +85,9 @@ Two things to know:
 
   - Linked sandboxes addressed by DNS name or sandbox id keep working. Traffic
     sent to a peer's raw docker0 address is denied.
-  - The rule covers sandboxes on the default bridge. If CONTAINER_NETWORK places
-    them on a user-defined bridge it does not apply, and the installer logs a
-    warning.
+  - The rule covers sandboxes on the default bridge, which is what this chart
+    produces. It would not apply if sandboxes were moved to another bridge.
+    Confirm from the DOCKER-USER packet counters rather than assuming.
 
 Verify enforcement from kernel state rather than from this chart's output:
 

--- a/charts/daytona-region/templates/NOTES.txt
+++ b/charts/daytona-region/templates/NOTES.txt
@@ -71,3 +71,29 @@ To trust this certificate in your system, add the CA certificate to your
 trust store. Instructions vary by operating system.
 
 {{- end }}
+
+{{- if and .Values.services.runner.enabled .Values.services.runner.sandboxIsolation.enabled }}
+
+Inter-sandbox isolation is ON (services.runner.sandboxIsolation.enabled).
+
+Sandboxes on the same runner node cannot reach each other over the host default
+bridge, including sandboxes belonging to the same organization. Use linked
+sandboxes where two sandboxes need to talk; they are placed on their own bridge
+and are unaffected.
+
+Two things to know:
+
+  - Linked sandboxes addressed by DNS name or sandbox id keep working. Traffic
+    sent to a peer's raw docker0 address is denied.
+  - The rule covers sandboxes on the default bridge. If CONTAINER_NETWORK places
+    them on a user-defined bridge it does not apply, and the installer logs a
+    warning.
+
+Verify enforcement from kernel state rather than from this chart's output:
+
+  iptables -L DOCKER-USER -n -v
+  sysctl net.bridge.bridge-nf-call-iptables
+
+To run without it, set services.runner.sandboxIsolation.enabled=false. The rule
+is then removed from each node on the next DaemonSet roll.
+{{- end }}

--- a/charts/daytona-region/templates/runner-daemonset.yaml
+++ b/charts/daytona-region/templates/runner-daemonset.yaml
@@ -7,7 +7,7 @@
   rendered when that container is absent. Reject the combination rather than silently
   shipping a runner with no isolation while values claim it is enabled.
 */ -}}
-{{- if and .Values.services.runner.sandboxIsolation.enabled (not .Values.services.runner.dockerInstaller.enabled) }}
+{{- if and .Values.services.runner.enabled .Values.services.runner.sandboxIsolation.enabled (not .Values.services.runner.dockerInstaller.enabled) }}
 {{-   fail "services.runner.sandboxIsolation.enabled=true requires services.runner.dockerInstaller.enabled=true (the peer-denial control is applied by the docker-installer). Set services.runner.sandboxIsolation.enabled=false to run without inter-sandbox isolation, and provide an equivalent host-level control yourself." }}
 {{- end }}
 {{- if .Values.services.runner.enabled }}
@@ -736,7 +736,10 @@ spec:
               echo "Asserting sandbox peer-denial..."
               if ! /usr/local/sbin/daytona-peer-denial.sh; then
                 echo "FATAL: sandbox peer-denial could not be established; refusing to report this node healthy"
-                exit 1
+                # Distinct code: the outer shell treats only this as fatal. The rest of this
+                # bootstrap script was never written to be exit-status clean, so gating the
+                # container on its overall status would crash nodes for unrelated reasons.
+                exit 3
               fi
 {{- end }}
 
@@ -752,6 +755,16 @@ spec:
               systemctl status sysbox --no-pager -l || echo "Sysbox service status not available"
               
               EOF
+              bootstrap_rc=$?
+{{- if .Values.services.runner.sandboxIsolation.enabled }}
+              # Propagate the peer-denial failure out of nsenter. Without this the inner
+              # exit is swallowed and the container proceeds as though the node were
+              # protected.
+              if [ "$bootstrap_rc" = 3 ]; then
+                echo "FATAL: host bootstrap could not establish sandbox peer-denial; exiting"
+                exit 1
+              fi
+{{- end }}
               
               echo "Docker and Sysbox installer initialized. Monitoring services..."
               

--- a/charts/daytona-region/templates/runner-daemonset.yaml
+++ b/charts/daytona-region/templates/runner-daemonset.yaml
@@ -527,13 +527,18 @@ spec:
                 
                 # Write Docker daemon config with Sysbox runtime
                 # Note: Not including storage-driver to avoid conflicts with GKE systemd flags
-                # icc=false denies container-to-container traffic on the default bridge.
-                # It only takes effect on a daemon start with no running containers: moby skips
-                # configureNetworking when live-restore hands it active sandboxes, so on an
-                # in-place upgrade this key is inert and docker0 keeps EnableICC=true from the
-                # bridge store. Peer denial therefore does NOT rest on this key -- see the
-                # DOCKER-USER rule asserted by ensure_sandbox_peer_denial below, which needs no
-                # daemon restart. This key covers freshly provisioned nodes.
+                # icc=false does two things, neither of which is the whole control.
+                # 1. It makes moby load br_netfilter and set bridge-nf-call-iptables=1
+                #    (moby libnetwork/drivers/bridge/bridge_linux.go:849-851), which is the
+                #    precondition the DOCKER-USER rule needs to see same-bridge traffic at all.
+                # 2. It installs moby's own FORWARD drop before any pod schedules, which covers
+                #    the boot window the DaemonSet cannot.
+                # Both only happen on a daemon start with no running containers: moby skips
+                # configureNetworking when live-restore hands it active sandboxes
+                # (daemon/daemon_unix.go:848-850), so on an in-place upgrade this key is inert.
+                # daytona-peer-denial.sh therefore asserts the same precondition itself and
+                # carries the running population.
+                # NOTE: changing this file makes the installer restart dockerd once per node.
                 cat > /etc/docker/daemon.json << 'DOCKERCONFIG'
               {
                 "runtimes": {
@@ -542,7 +547,9 @@ spec:
                   }
                 },
                 "default-runtime": "sysbox-runc",
+                {{- if .Values.services.runner.sandboxIsolation.enabled }}
                 "icc": false,
+                {{- end }}
                 {{- if .Values.services.runner.dockerInstaller.liveRestore }}
                 "live-restore": true,
                 {{- end }}
@@ -599,29 +606,83 @@ spec:
               echo "BuildKit DNS config written to /etc/buildkit/buildkitd.toml"
               {{- end }}
               
-              # Start Sysbox services
-              # Deny traffic between unrelated sandboxes on the default bridge.
+{{- if .Values.services.runner.sandboxIsolation.enabled }}
+              # Single-source the peer-denial logic to a host script. The bootstrap heredoc and
+              # the monitor loop run in separate shells and cannot share a function, and an
+              # inline copy in each has already been observed to drift.
+              cat > /usr/local/sbin/daytona-peer-denial.sh << 'PEERDENIAL'
+              #!/bin/sh
+              # Deny traffic between unrelated sandboxes on the host default bridge.
               #
-              # This is the control that actually holds. It lives in DOCKER-USER, which docker
-              # never flushes, so it survives a dockerd restart and -- unlike the icc key -- it
-              # applies immediately to sandboxes that are already running.
+              # Scope: exactly one topology -- sandboxes on docker0. It does not apply when
+              # CONTAINER_NETWORK puts sandboxes on a br-<id> bridge.
               #
-              # Anchored on -i docker0 -o docker0, so it matches only same-bridge peer traffic.
-              # Deliberately linked sandboxes are unaffected: the runner puts them on their own
-              # link bridge and anchors its ACCEPT rules to that interface, so the two rules can
-              # never match the same packet and their relative order does not matter.
+              # Contract with linked sandboxes: both peers hold a docker0 endpoint AND a link
+              # endpoint. DNS by name and by sandbox id resolves to the link address, so linked
+              # traffic is unaffected. Traffic addressed to a peer's raw docker0 address IS
+              # denied -- intentionally, since an interface matcher cannot tell it apart from
+              # unrelated-tenant traffic.
               #
-              # Check-then-insert: a bare -I on a 60s reconcile stacks a duplicate every pass.
-              ensure_sandbox_peer_denial() {
-                iptables -w -C DOCKER-USER -i docker0 -o docker0 -j DROP 2>/dev/null \
-                  || iptables -w -I DOCKER-USER 1 -i docker0 -o docker0 -j DROP
-                # Best effort: only reachable if the operator enabled IPv6 on the bridge.
-                if command -v ip6tables >/dev/null 2>&1; then
-                  ip6tables -w -C DOCKER-USER -i docker0 -o docker0 -j DROP 2>/dev/null \
-                    || ip6tables -w -I DOCKER-USER 1 -i docker0 -o docker0 -j DROP 2>/dev/null || true
-                fi
-              }
+              # Invariant: nothing above this rule in DOCKER-USER may ACCEPT sandbox peer
+              # traffic. The runner anchors its link ACCEPTs to -i <link-bridge> for exactly
+              # this reason (apps/runner/pkg/netrules/link_icc.go); keep it that way.
+              set -u
+              rc=0
 
+              # Kernel precondition. Same-bridge frames are switched at L2 and reach iptables
+              # only when br_netfilter is loaded with bridge-nf-call-iptables=1. Docker
+              # provisions this itself when icc=false, but only on a daemon start with no
+              # running containers -- so on an in-place upgrade it is absent and the rule below
+              # would install cleanly and filter nothing. Assert it here and read it back.
+              modprobe br_netfilter 2>/dev/null || true
+              echo 1 > /proc/sys/net/bridge/bridge-nf-call-iptables 2>/dev/null || true
+              echo 1 > /proc/sys/net/bridge/bridge-nf-call-ip6tables 2>/dev/null || true
+              echo br_netfilter > /etc/modules-load.d/daytona-sandbox-isolation.conf 2>/dev/null || true
+              printf 'net.bridge.bridge-nf-call-iptables = 1\nnet.bridge.bridge-nf-call-ip6tables = 1\n' \
+                > /etc/sysctl.d/99-daytona-sandbox-isolation.conf 2>/dev/null || true
+              nf=$(cat /proc/sys/net/bridge/bridge-nf-call-iptables 2>/dev/null || echo missing)
+              if [ "$nf" != "1" ]; then
+                echo "ERROR: bridge-nf-call-iptables=$nf -- the peer-denial rule will NOT filter same-bridge traffic on this node"
+                rc=1
+              fi
+
+              # Check-then-insert: a bare -I on a reconcile stacks a duplicate every pass.
+              if ! iptables -w -C DOCKER-USER -i docker0 -o docker0 -j DROP 2>/dev/null; then
+                if iptables -w -I DOCKER-USER 1 -i docker0 -o docker0 -j DROP; then
+                  echo "Installed IPv4 sandbox peer-denial rule"
+                else
+                  echo "ERROR: failed to install IPv4 sandbox peer-denial rule"
+                  rc=1
+                fi
+              fi
+
+              # ip6tables defaults on from Docker 27.4.1, so this chain exists. Non-fatal, but
+              # never silent: containers can hold IPv6 addresses and sandbox services bind ::.
+              if ! ip6tables -w -C DOCKER-USER -i docker0 -o docker0 -j DROP 2>/dev/null; then
+                if ip6tables -w -I DOCKER-USER 1 -i docker0 -o docker0 -j DROP 2>/dev/null; then
+                  echo "Installed IPv6 sandbox peer-denial rule"
+                else
+                  echo "WARNING: failed to install IPv6 sandbox peer-denial rule; IPv6 peer traffic is not denied"
+                fi
+              fi
+
+              exit $rc
+              PEERDENIAL
+              sed -i 's/^              //' /usr/local/sbin/daytona-peer-denial.sh
+              chmod 0755 /usr/local/sbin/daytona-peer-denial.sh
+{{- else }}
+              # sandboxIsolation disabled: remove the rules and the script rather than
+              # orphaning a DROP that nothing else will ever delete.
+              rm -f /usr/local/sbin/daytona-peer-denial.sh /etc/sysctl.d/99-daytona-sandbox-isolation.conf
+              while iptables -w -C DOCKER-USER -i docker0 -o docker0 -j DROP 2>/dev/null; do
+                iptables -w -D DOCKER-USER -i docker0 -o docker0 -j DROP || break
+              done
+              while ip6tables -w -C DOCKER-USER -i docker0 -o docker0 -j DROP 2>/dev/null; do
+                ip6tables -w -D DOCKER-USER -i docker0 -o docker0 -j DROP || break
+              done
+{{- end }}
+
+              # Start Sysbox services
               echo "Starting Sysbox services..."
               systemctl enable sysbox 2>/dev/null || true
               systemctl start sysbox 2>/dev/null || true
@@ -647,9 +708,12 @@ spec:
                 echo "Docker already running with Sysbox runtime and unchanged config; skipping restart to avoid disrupting running sandboxes"
               fi
               
+{{- if .Values.services.runner.sandboxIsolation.enabled }}
               # Assert peer denial now that dockerd is up and DOCKER-USER exists.
-              echo "Asserting sandbox peer-denial rule..."
-              ensure_sandbox_peer_denial || echo "WARNING: failed to assert sandbox peer-denial rule"
+              echo "Asserting sandbox peer-denial..."
+              /usr/local/sbin/daytona-peer-denial.sh \
+                || echo "WARNING: sandbox peer-denial assert FAILED -- peers may be reachable on this node"
+{{- end }}
 
               # Verify installation
               echo "=== Verification ==="
@@ -675,17 +739,22 @@ spec:
                     systemctl start sysbox 2>/dev/null || echo "Failed to start Sysbox"
                   fi
                   
-                  # Check Docker
+                  # Check Docker. Each check reports its own failure: the payload exit
+                  # status is fixed at 0 below, so no later command can mask an earlier one.
                   if ! systemctl is-active --quiet docker; then
                     echo "Docker service is down, restarting..."
-                    systemctl start docker
+                    systemctl start docker || echo "Failed to start Docker"
                   fi
+{{- if .Values.services.runner.sandboxIsolation.enabled }}
 
                   # Re-assert sandbox peer denial. DOCKER-USER survives a dockerd restart, but
                   # re-check anyway: an operator iptables flush would otherwise silently reopen
                   # peer reachability until the next pod start.
-                  iptables -w -C DOCKER-USER -i docker0 -o docker0 -j DROP 2>/dev/null \
-                    || iptables -w -I DOCKER-USER 1 -i docker0 -o docker0 -j DROP
+                  /usr/local/sbin/daytona-peer-denial.sh \
+                    || echo "WARNING: sandbox peer-denial re-assert FAILED"
+{{- end }}
+
+                  exit 0
                 ' || echo "Health check failed, will retry..."
                 sleep 60
               done

--- a/charts/daytona-region/templates/runner-daemonset.yaml
+++ b/charts/daytona-region/templates/runner-daemonset.yaml
@@ -527,6 +527,13 @@ spec:
                 
                 # Write Docker daemon config with Sysbox runtime
                 # Note: Not including storage-driver to avoid conflicts with GKE systemd flags
+                # icc=false denies container-to-container traffic on the default bridge.
+                # It only takes effect on a daemon start with no running containers: moby skips
+                # configureNetworking when live-restore hands it active sandboxes, so on an
+                # in-place upgrade this key is inert and docker0 keeps EnableICC=true from the
+                # bridge store. Peer denial therefore does NOT rest on this key -- see the
+                # DOCKER-USER rule asserted by ensure_sandbox_peer_denial below, which needs no
+                # daemon restart. This key covers freshly provisioned nodes.
                 cat > /etc/docker/daemon.json << 'DOCKERCONFIG'
               {
                 "runtimes": {
@@ -535,6 +542,7 @@ spec:
                   }
                 },
                 "default-runtime": "sysbox-runc",
+                "icc": false,
                 {{- if .Values.services.runner.dockerInstaller.liveRestore }}
                 "live-restore": true,
                 {{- end }}
@@ -592,6 +600,28 @@ spec:
               {{- end }}
               
               # Start Sysbox services
+              # Deny traffic between unrelated sandboxes on the default bridge.
+              #
+              # This is the control that actually holds. It lives in DOCKER-USER, which docker
+              # never flushes, so it survives a dockerd restart and -- unlike the icc key -- it
+              # applies immediately to sandboxes that are already running.
+              #
+              # Anchored on -i docker0 -o docker0, so it matches only same-bridge peer traffic.
+              # Deliberately linked sandboxes are unaffected: the runner puts them on their own
+              # link bridge and anchors its ACCEPT rules to that interface, so the two rules can
+              # never match the same packet and their relative order does not matter.
+              #
+              # Check-then-insert: a bare -I on a 60s reconcile stacks a duplicate every pass.
+              ensure_sandbox_peer_denial() {
+                iptables -w -C DOCKER-USER -i docker0 -o docker0 -j DROP 2>/dev/null \
+                  || iptables -w -I DOCKER-USER 1 -i docker0 -o docker0 -j DROP
+                # Best effort: only reachable if the operator enabled IPv6 on the bridge.
+                if command -v ip6tables >/dev/null 2>&1; then
+                  ip6tables -w -C DOCKER-USER -i docker0 -o docker0 -j DROP 2>/dev/null \
+                    || ip6tables -w -I DOCKER-USER 1 -i docker0 -o docker0 -j DROP 2>/dev/null || true
+                fi
+              }
+
               echo "Starting Sysbox services..."
               systemctl enable sysbox 2>/dev/null || true
               systemctl start sysbox 2>/dev/null || true
@@ -617,6 +647,10 @@ spec:
                 echo "Docker already running with Sysbox runtime and unchanged config; skipping restart to avoid disrupting running sandboxes"
               fi
               
+              # Assert peer denial now that dockerd is up and DOCKER-USER exists.
+              echo "Asserting sandbox peer-denial rule..."
+              ensure_sandbox_peer_denial || echo "WARNING: failed to assert sandbox peer-denial rule"
+
               # Verify installation
               echo "=== Verification ==="
               echo "Docker version:"
@@ -646,6 +680,12 @@ spec:
                     echo "Docker service is down, restarting..."
                     systemctl start docker
                   fi
+
+                  # Re-assert sandbox peer denial. DOCKER-USER survives a dockerd restart, but
+                  # re-check anyway: an operator iptables flush would otherwise silently reopen
+                  # peer reachability until the next pod start.
+                  iptables -w -C DOCKER-USER -i docker0 -o docker0 -j DROP 2>/dev/null \
+                    || iptables -w -I DOCKER-USER 1 -i docker0 -o docker0 -j DROP
                 ' || echo "Health check failed, will retry..."
                 sleep 60
               done

--- a/charts/daytona-region/templates/runner-daemonset.yaml
+++ b/charts/daytona-region/templates/runner-daemonset.yaml
@@ -1,3 +1,15 @@
+{{- /*
+  Isolation contract:
+    sandboxIsolation.enabled: false -> intentional operator opt-out.
+    sandboxIsolation.enabled: true  -> isolation is enforced, or the installer fails closed.
+    dockerInstaller.enabled         -> controls Docker/Sysbox installation ONLY.
+  The peer-denial control is applied by the docker-installer container, so it cannot be
+  rendered when that container is absent. Reject the combination rather than silently
+  shipping a runner with no isolation while values claim it is enabled.
+*/ -}}
+{{- if and .Values.services.runner.sandboxIsolation.enabled (not .Values.services.runner.dockerInstaller.enabled) }}
+{{-   fail "services.runner.sandboxIsolation.enabled=true requires services.runner.dockerInstaller.enabled=true (the peer-denial control is applied by the docker-installer). Set services.runner.sandboxIsolation.enabled=false to run without inter-sandbox isolation, and provide an equivalent host-level control yourself." }}
+{{- end }}
 {{- if .Values.services.runner.enabled }}
 apiVersion: apps/v1
 kind: DaemonSet
@@ -656,13 +668,16 @@ spec:
                 fi
               fi
 
-              # ip6tables defaults on from Docker 27.4.1, so this chain exists. Non-fatal, but
-              # never silent: containers can hold IPv6 addresses and sandbox services bind ::.
+              # ip6tables defaults on from Docker 27.4.1 (cmd/dockerd/config_unix.go:31), so this
+              # chain exists on every node this chart provisions and a failure here is a real
+              # gap, not an absent feature: containers can hold IPv6 addresses and sandbox
+              # services bind ::. Counts toward the exit status.
               if ! ip6tables -w -C DOCKER-USER -i docker0 -o docker0 -j DROP 2>/dev/null; then
-                if ip6tables -w -I DOCKER-USER 1 -i docker0 -o docker0 -j DROP 2>/dev/null; then
+                if ip6tables -w -I DOCKER-USER 1 -i docker0 -o docker0 -j DROP; then
                   echo "Installed IPv6 sandbox peer-denial rule"
                 else
-                  echo "WARNING: failed to install IPv6 sandbox peer-denial rule; IPv6 peer traffic is not denied"
+                  echo "ERROR: failed to install IPv6 sandbox peer-denial rule; IPv6 peer traffic is NOT denied"
+                  rc=1
                 fi
               fi
 
@@ -710,9 +725,19 @@ spec:
               
 {{- if .Values.services.runner.sandboxIsolation.enabled }}
               # Assert peer denial now that dockerd is up and DOCKER-USER exists.
+              #
+              # FAIL CLOSED. If isolation is enabled and cannot be established, this container
+              # exits non-zero rather than leaving the node running while values claim peers
+              # are denied. The node becomes visibly broken instead of quietly unprotected.
+              #
+              # Limit worth knowing: in the runner-manager topology this DaemonSet only
+              # bootstraps the node, so a crash here does not by itself stop sandboxes being
+              # placed on it. Blocking admission requires the runner-side health probe.
               echo "Asserting sandbox peer-denial..."
-              /usr/local/sbin/daytona-peer-denial.sh \
-                || echo "WARNING: sandbox peer-denial assert FAILED -- peers may be reachable on this node"
+              if ! /usr/local/sbin/daytona-peer-denial.sh; then
+                echo "FATAL: sandbox peer-denial could not be established; refusing to report this node healthy"
+                exit 1
+              fi
 {{- end }}
 
               # Verify installation
@@ -750,12 +775,23 @@ spec:
                   # Re-assert sandbox peer denial. DOCKER-USER survives a dockerd restart, but
                   # re-check anyway: an operator iptables flush would otherwise silently reopen
                   # peer reachability until the next pod start.
-                  /usr/local/sbin/daytona-peer-denial.sh \
-                    || echo "WARNING: sandbox peer-denial re-assert FAILED"
+                  #
+                  # Fail closed: exit non-zero so the container restarts and re-runs the full
+                  # bootstrap assert, rather than looping forever on an unprotected node.
+                  if ! /usr/local/sbin/daytona-peer-denial.sh; then
+                    echo "FATAL: sandbox peer-denial re-assert failed"
+                    exit 1
+                  fi
 {{- end }}
 
                   exit 0
-                ' || echo "Health check failed, will retry..."
+                ' || { rc=$?
+                  if [ "$rc" = 1 ]; then
+                    echo "Sandbox peer-denial enforcement lost; exiting so the container restarts"
+                    exit 1
+                  fi
+                  echo "Health check failed, will retry..."
+                }
                 sleep 60
               done
               ln -s /host/var/lib/docker /var/lib/docker

--- a/charts/daytona-region/templates/runner-daemonset.yaml
+++ b/charts/daytona-region/templates/runner-daemonset.yaml
@@ -626,8 +626,8 @@ spec:
               #!/bin/sh
               # Deny traffic between unrelated sandboxes on the host default bridge.
               #
-              # Scope: exactly one topology -- sandboxes on docker0. It does not apply when
-              # CONTAINER_NETWORK puts sandboxes on a br-<id> bridge.
+              # Scope: exactly one topology -- sandboxes on docker0, which is what this
+              # chart produces. It does not apply if sandboxes are moved to another bridge.
               #
               # Contract with linked sandboxes: both peers hold a docker0 endpoint AND a link
               # endpoint. DNS by name and by sandbox id resolves to the link address, so linked
@@ -653,12 +653,16 @@ spec:
               echo br_netfilter > /etc/modules-load.d/daytona-sandbox-isolation.conf 2>/dev/null || true
               printf 'net.bridge.bridge-nf-call-iptables = 1\nnet.bridge.bridge-nf-call-ip6tables = 1\n' \
                 > /etc/sysctl.d/99-daytona-sandbox-isolation.conf 2>/dev/null || true
-              # The rule is anchored to docker0. If sandboxes are placed elsewhere (for
-              # example CONTAINER_NETWORK on a user-defined bridge, where ICC is on by
-              # default) it matches nothing. Say so rather than reporting a silent success.
-              if ! ip link show docker0 >/dev/null 2>&1; then
-                echo "WARNING: docker0 is not present on this node; the sandbox peer-denial rule matches no traffic"
-              fi
+              # Scope note, deliberately not a runtime check. The rule is anchored to
+              # docker0, so it matches nothing if sandboxes are placed on another bridge.
+              # A presence test on docker0 would not detect that: Docker creates docker0
+              # regardless of where containers are attached. Detecting it properly means
+              # checking where sandboxes actually land, and the configuration that would
+              # move them (CONTAINER_NETWORK) is not reachable through this chart at all --
+              # the runner ConfigMap is a fixed key list that does not carry it, and
+              # extraEnv renders only under mainContainer.enabled. The honest signal is the
+              # DOCKER-USER packet counters logged below: a rule matching nothing stays at
+              # zero. Revisit if CONTAINER_NETWORK ever becomes settable here.
 
               nf=$(cat /proc/sys/net/bridge/bridge-nf-call-iptables 2>/dev/null || echo missing)
               if [ "$nf" != "1" ]; then

--- a/charts/daytona-region/templates/runner-daemonset.yaml
+++ b/charts/daytona-region/templates/runner-daemonset.yaml
@@ -640,6 +640,7 @@ spec:
               # this reason (apps/runner/pkg/netrules/link_icc.go); keep it that way.
               set -u
               rc=0
+              changed=0
 
               # Kernel precondition. Same-bridge frames are switched at L2 and reach iptables
               # only when br_netfilter is loaded with bridge-nf-call-iptables=1. Docker
@@ -652,6 +653,13 @@ spec:
               echo br_netfilter > /etc/modules-load.d/daytona-sandbox-isolation.conf 2>/dev/null || true
               printf 'net.bridge.bridge-nf-call-iptables = 1\nnet.bridge.bridge-nf-call-ip6tables = 1\n' \
                 > /etc/sysctl.d/99-daytona-sandbox-isolation.conf 2>/dev/null || true
+              # The rule is anchored to docker0. If sandboxes are placed elsewhere (for
+              # example CONTAINER_NETWORK on a user-defined bridge, where ICC is on by
+              # default) it matches nothing. Say so rather than reporting a silent success.
+              if ! ip link show docker0 >/dev/null 2>&1; then
+                echo "WARNING: docker0 is not present on this node; the sandbox peer-denial rule matches no traffic"
+              fi
+
               nf=$(cat /proc/sys/net/bridge/bridge-nf-call-iptables 2>/dev/null || echo missing)
               if [ "$nf" != "1" ]; then
                 echo "ERROR: bridge-nf-call-iptables=$nf -- the peer-denial rule will NOT filter same-bridge traffic on this node"
@@ -659,9 +667,10 @@ spec:
               fi
 
               # Check-then-insert: a bare -I on a reconcile stacks a duplicate every pass.
-              if ! iptables -w -C DOCKER-USER -i docker0 -o docker0 -j DROP 2>/dev/null; then
-                if iptables -w -I DOCKER-USER 1 -i docker0 -o docker0 -j DROP; then
+              if ! iptables -w 5 -C DOCKER-USER -i docker0 -o docker0 -j DROP 2>/dev/null; then
+                if iptables -w 5 -I DOCKER-USER 1 -i docker0 -o docker0 -j DROP; then
                   echo "Installed IPv4 sandbox peer-denial rule"
+                  changed=1
                 else
                   echo "ERROR: failed to install IPv4 sandbox peer-denial rule"
                   rc=1
@@ -675,10 +684,19 @@ spec:
               if ! ip6tables -w -C DOCKER-USER -i docker0 -o docker0 -j DROP 2>/dev/null; then
                 if ip6tables -w -I DOCKER-USER 1 -i docker0 -o docker0 -j DROP; then
                   echo "Installed IPv6 sandbox peer-denial rule"
+                  changed=1
                 else
                   echo "ERROR: failed to install IPv6 sandbox peer-denial rule; IPv6 peer traffic is NOT denied"
                   rc=1
                 fi
+              fi
+
+              # Log the chain when we changed something or could not enforce. Silent on a
+              # steady-state reconcile, so the 60s loop does not spam the node log.
+              if [ "$changed" = 1 ] || [ "$rc" != 0 ]; then
+                echo "DOCKER-USER after assert:"
+                iptables -w 5 -L DOCKER-USER -n -v 2>/dev/null | head -20 || true
+                echo "bridge-nf-call-iptables=$nf"
               fi
 
               exit $rc
@@ -688,9 +706,11 @@ spec:
 {{- else }}
               # sandboxIsolation disabled: remove the rules and the script rather than
               # orphaning a DROP that nothing else will ever delete.
-              rm -f /usr/local/sbin/daytona-peer-denial.sh /etc/sysctl.d/99-daytona-sandbox-isolation.conf
-              while iptables -w -C DOCKER-USER -i docker0 -o docker0 -j DROP 2>/dev/null; do
-                iptables -w -D DOCKER-USER -i docker0 -o docker0 -j DROP || break
+              rm -f /usr/local/sbin/daytona-peer-denial.sh \
+                    /etc/sysctl.d/99-daytona-sandbox-isolation.conf \
+                    /etc/modules-load.d/daytona-sandbox-isolation.conf
+              while iptables -w 5 -C DOCKER-USER -i docker0 -o docker0 -j DROP 2>/dev/null; do
+                iptables -w 5 -D DOCKER-USER -i docker0 -o docker0 -j DROP || break
               done
               while ip6tables -w -C DOCKER-USER -i docker0 -o docker0 -j DROP 2>/dev/null; do
                 ip6tables -w -D DOCKER-USER -i docker0 -o docker0 -j DROP || break
@@ -708,12 +728,27 @@ spec:
               # and stops every running sandbox that predates live-restore taking
               # effect, so we avoid restarting unless it is truly necessary.
               echo "Ensuring Docker is running with the Sysbox runtime..."
+              # Decide whether the daemon config changed in a way that warrants a restart.
+              # The icc key is deliberately excluded from the comparison. It only takes effect
+              # on a daemon start with no running containers, so bouncing dockerd to apply it
+              # either does nothing (live-restore on: sandboxes survive, moby skips
+              # configureNetworking) or stops every sandbox on the node to apply a key the
+              # DOCKER-USER rule already covers. The key still lands in daemon.json and applies
+              # at the next natural restart, which is a reboot or a fresh node -- both of which
+              # start dockerd clean anyway.
+              daemon_json_changed=0
+              if [ -f /etc/docker/daemon.json.bak ]; then
+                grep -v '"icc"' /etc/docker/daemon.json > /tmp/daytona-dj-new 2>/dev/null || true
+                grep -v '"icc"' /etc/docker/daemon.json.bak > /tmp/daytona-dj-old 2>/dev/null || true
+                cmp -s /tmp/daytona-dj-new /tmp/daytona-dj-old || daemon_json_changed=1
+                rm -f /tmp/daytona-dj-new /tmp/daytona-dj-old
+              fi
               need_restart=0
               if ! systemctl is-active --quiet docker; then
                 need_restart=1
               elif ! docker info 2>/dev/null | grep -q 'sysbox-runc'; then
                 need_restart=1
-              elif [ -f /etc/docker/daemon.json.bak ] && ! cmp -s /etc/docker/daemon.json /etc/docker/daemon.json.bak; then
+              elif [ "$daemon_json_changed" = 1 ]; then
                 need_restart=1
               fi
               if [ "$need_restart" = 1 ]; then

--- a/charts/daytona-region/tests/baselines/rendered-baseline.yaml
+++ b/charts/daytona-region/tests/baselines/rendered-baseline.yaml
@@ -682,6 +682,13 @@ spec:
                 
                 # Write Docker daemon config with Sysbox runtime
                 # Note: Not including storage-driver to avoid conflicts with GKE systemd flags
+                # icc=false denies container-to-container traffic on the default bridge.
+                # It only takes effect on a daemon start with no running containers: moby skips
+                # configureNetworking when live-restore hands it active sandboxes, so on an
+                # in-place upgrade this key is inert and docker0 keeps EnableICC=true from the
+                # bridge store. Peer denial therefore does NOT rest on this key -- see the
+                # DOCKER-USER rule asserted by ensure_sandbox_peer_denial below, which needs no
+                # daemon restart. This key covers freshly provisioned nodes.
                 cat > /etc/docker/daemon.json << 'DOCKERCONFIG'
               {
                 "runtimes": {
@@ -690,6 +697,7 @@ spec:
                   }
                 },
                 "default-runtime": "sysbox-runc",
+                "icc": false,
                 "live-restore": true,
                 "log-driver": "json-file",
                 "log-opts": {
@@ -716,6 +724,28 @@ spec:
               configure_docker_sysbox
               
               # Start Sysbox services
+              # Deny traffic between unrelated sandboxes on the default bridge.
+              #
+              # This is the control that actually holds. It lives in DOCKER-USER, which docker
+              # never flushes, so it survives a dockerd restart and -- unlike the icc key -- it
+              # applies immediately to sandboxes that are already running.
+              #
+              # Anchored on -i docker0 -o docker0, so it matches only same-bridge peer traffic.
+              # Deliberately linked sandboxes are unaffected: the runner puts them on their own
+              # link bridge and anchors its ACCEPT rules to that interface, so the two rules can
+              # never match the same packet and their relative order does not matter.
+              #
+              # Check-then-insert: a bare -I on a 60s reconcile stacks a duplicate every pass.
+              ensure_sandbox_peer_denial() {
+                iptables -w -C DOCKER-USER -i docker0 -o docker0 -j DROP 2>/dev/null \
+                  || iptables -w -I DOCKER-USER 1 -i docker0 -o docker0 -j DROP
+                # Best effort: only reachable if the operator enabled IPv6 on the bridge.
+                if command -v ip6tables >/dev/null 2>&1; then
+                  ip6tables -w -C DOCKER-USER -i docker0 -o docker0 -j DROP 2>/dev/null \
+                    || ip6tables -w -I DOCKER-USER 1 -i docker0 -o docker0 -j DROP 2>/dev/null || true
+                fi
+              }
+
               echo "Starting Sysbox services..."
               systemctl enable sysbox 2>/dev/null || true
               systemctl start sysbox 2>/dev/null || true
@@ -741,6 +771,10 @@ spec:
                 echo "Docker already running with Sysbox runtime and unchanged config; skipping restart to avoid disrupting running sandboxes"
               fi
               
+              # Assert peer denial now that dockerd is up and DOCKER-USER exists.
+              echo "Asserting sandbox peer-denial rule..."
+              ensure_sandbox_peer_denial || echo "WARNING: failed to assert sandbox peer-denial rule"
+
               # Verify installation
               echo "=== Verification ==="
               echo "Docker version:"
@@ -770,6 +804,12 @@ spec:
                     echo "Docker service is down, restarting..."
                     systemctl start docker
                   fi
+
+                  # Re-assert sandbox peer denial. DOCKER-USER survives a dockerd restart, but
+                  # re-check anyway: an operator iptables flush would otherwise silently reopen
+                  # peer reachability until the next pod start.
+                  iptables -w -C DOCKER-USER -i docker0 -o docker0 -j DROP 2>/dev/null \
+                    || iptables -w -I DOCKER-USER 1 -i docker0 -o docker0 -j DROP
                 ' || echo "Health check failed, will retry..."
                 sleep 60
               done

--- a/charts/daytona-region/tests/baselines/rendered-baseline.yaml
+++ b/charts/daytona-region/tests/baselines/rendered-baseline.yaml
@@ -831,7 +831,10 @@ spec:
               echo "Asserting sandbox peer-denial..."
               if ! /usr/local/sbin/daytona-peer-denial.sh; then
                 echo "FATAL: sandbox peer-denial could not be established; refusing to report this node healthy"
-                exit 1
+                # Distinct code: the outer shell treats only this as fatal. The rest of this
+                # bootstrap script was never written to be exit-status clean, so gating the
+                # container on its overall status would crash nodes for unrelated reasons.
+                exit 3
               fi
 
               # Verify installation
@@ -846,6 +849,14 @@ spec:
               systemctl status sysbox --no-pager -l || echo "Sysbox service status not available"
               
               EOF
+              bootstrap_rc=$?
+              # Propagate the peer-denial failure out of nsenter. Without this the inner
+              # exit is swallowed and the container proceeds as though the node were
+              # protected.
+              if [ "$bootstrap_rc" = 3 ]; then
+                echo "FATAL: host bootstrap could not establish sandbox peer-denial; exiting"
+                exit 1
+              fi
               
               echo "Docker and Sysbox installer initialized. Monitoring services..."
               

--- a/charts/daytona-region/tests/baselines/rendered-baseline.yaml
+++ b/charts/daytona-region/tests/baselines/rendered-baseline.yaml
@@ -748,6 +748,7 @@ spec:
               # this reason (apps/runner/pkg/netrules/link_icc.go); keep it that way.
               set -u
               rc=0
+              changed=0
 
               # Kernel precondition. Same-bridge frames are switched at L2 and reach iptables
               # only when br_netfilter is loaded with bridge-nf-call-iptables=1. Docker
@@ -760,6 +761,13 @@ spec:
               echo br_netfilter > /etc/modules-load.d/daytona-sandbox-isolation.conf 2>/dev/null || true
               printf 'net.bridge.bridge-nf-call-iptables = 1\nnet.bridge.bridge-nf-call-ip6tables = 1\n' \
                 > /etc/sysctl.d/99-daytona-sandbox-isolation.conf 2>/dev/null || true
+              # The rule is anchored to docker0. If sandboxes are placed elsewhere (for
+              # example CONTAINER_NETWORK on a user-defined bridge, where ICC is on by
+              # default) it matches nothing. Say so rather than reporting a silent success.
+              if ! ip link show docker0 >/dev/null 2>&1; then
+                echo "WARNING: docker0 is not present on this node; the sandbox peer-denial rule matches no traffic"
+              fi
+
               nf=$(cat /proc/sys/net/bridge/bridge-nf-call-iptables 2>/dev/null || echo missing)
               if [ "$nf" != "1" ]; then
                 echo "ERROR: bridge-nf-call-iptables=$nf -- the peer-denial rule will NOT filter same-bridge traffic on this node"
@@ -767,9 +775,10 @@ spec:
               fi
 
               # Check-then-insert: a bare -I on a reconcile stacks a duplicate every pass.
-              if ! iptables -w -C DOCKER-USER -i docker0 -o docker0 -j DROP 2>/dev/null; then
-                if iptables -w -I DOCKER-USER 1 -i docker0 -o docker0 -j DROP; then
+              if ! iptables -w 5 -C DOCKER-USER -i docker0 -o docker0 -j DROP 2>/dev/null; then
+                if iptables -w 5 -I DOCKER-USER 1 -i docker0 -o docker0 -j DROP; then
                   echo "Installed IPv4 sandbox peer-denial rule"
+                  changed=1
                 else
                   echo "ERROR: failed to install IPv4 sandbox peer-denial rule"
                   rc=1
@@ -783,10 +792,19 @@ spec:
               if ! ip6tables -w -C DOCKER-USER -i docker0 -o docker0 -j DROP 2>/dev/null; then
                 if ip6tables -w -I DOCKER-USER 1 -i docker0 -o docker0 -j DROP; then
                   echo "Installed IPv6 sandbox peer-denial rule"
+                  changed=1
                 else
                   echo "ERROR: failed to install IPv6 sandbox peer-denial rule; IPv6 peer traffic is NOT denied"
                   rc=1
                 fi
+              fi
+
+              # Log the chain when we changed something or could not enforce. Silent on a
+              # steady-state reconcile, so the 60s loop does not spam the node log.
+              if [ "$changed" = 1 ] || [ "$rc" != 0 ]; then
+                echo "DOCKER-USER after assert:"
+                iptables -w 5 -L DOCKER-USER -n -v 2>/dev/null | head -20 || true
+                echo "bridge-nf-call-iptables=$nf"
               fi
 
               exit $rc
@@ -805,12 +823,27 @@ spec:
               # and stops every running sandbox that predates live-restore taking
               # effect, so we avoid restarting unless it is truly necessary.
               echo "Ensuring Docker is running with the Sysbox runtime..."
+              # Decide whether the daemon config changed in a way that warrants a restart.
+              # The icc key is deliberately excluded from the comparison. It only takes effect
+              # on a daemon start with no running containers, so bouncing dockerd to apply it
+              # either does nothing (live-restore on: sandboxes survive, moby skips
+              # configureNetworking) or stops every sandbox on the node to apply a key the
+              # DOCKER-USER rule already covers. The key still lands in daemon.json and applies
+              # at the next natural restart, which is a reboot or a fresh node -- both of which
+              # start dockerd clean anyway.
+              daemon_json_changed=0
+              if [ -f /etc/docker/daemon.json.bak ]; then
+                grep -v '"icc"' /etc/docker/daemon.json > /tmp/daytona-dj-new 2>/dev/null || true
+                grep -v '"icc"' /etc/docker/daemon.json.bak > /tmp/daytona-dj-old 2>/dev/null || true
+                cmp -s /tmp/daytona-dj-new /tmp/daytona-dj-old || daemon_json_changed=1
+                rm -f /tmp/daytona-dj-new /tmp/daytona-dj-old
+              fi
               need_restart=0
               if ! systemctl is-active --quiet docker; then
                 need_restart=1
               elif ! docker info 2>/dev/null | grep -q 'sysbox-runc'; then
                 need_restart=1
-              elif [ -f /etc/docker/daemon.json.bak ] && ! cmp -s /etc/docker/daemon.json /etc/docker/daemon.json.bak; then
+              elif [ "$daemon_json_changed" = 1 ]; then
                 need_restart=1
               fi
               if [ "$need_restart" = 1 ]; then

--- a/charts/daytona-region/tests/baselines/rendered-baseline.yaml
+++ b/charts/daytona-region/tests/baselines/rendered-baseline.yaml
@@ -734,8 +734,8 @@ spec:
               #!/bin/sh
               # Deny traffic between unrelated sandboxes on the host default bridge.
               #
-              # Scope: exactly one topology -- sandboxes on docker0. It does not apply when
-              # CONTAINER_NETWORK puts sandboxes on a br-<id> bridge.
+              # Scope: exactly one topology -- sandboxes on docker0, which is what this
+              # chart produces. It does not apply if sandboxes are moved to another bridge.
               #
               # Contract with linked sandboxes: both peers hold a docker0 endpoint AND a link
               # endpoint. DNS by name and by sandbox id resolves to the link address, so linked
@@ -761,12 +761,16 @@ spec:
               echo br_netfilter > /etc/modules-load.d/daytona-sandbox-isolation.conf 2>/dev/null || true
               printf 'net.bridge.bridge-nf-call-iptables = 1\nnet.bridge.bridge-nf-call-ip6tables = 1\n' \
                 > /etc/sysctl.d/99-daytona-sandbox-isolation.conf 2>/dev/null || true
-              # The rule is anchored to docker0. If sandboxes are placed elsewhere (for
-              # example CONTAINER_NETWORK on a user-defined bridge, where ICC is on by
-              # default) it matches nothing. Say so rather than reporting a silent success.
-              if ! ip link show docker0 >/dev/null 2>&1; then
-                echo "WARNING: docker0 is not present on this node; the sandbox peer-denial rule matches no traffic"
-              fi
+              # Scope note, deliberately not a runtime check. The rule is anchored to
+              # docker0, so it matches nothing if sandboxes are placed on another bridge.
+              # A presence test on docker0 would not detect that: Docker creates docker0
+              # regardless of where containers are attached. Detecting it properly means
+              # checking where sandboxes actually land, and the configuration that would
+              # move them (CONTAINER_NETWORK) is not reachable through this chart at all --
+              # the runner ConfigMap is a fixed key list that does not carry it, and
+              # extraEnv renders only under mainContainer.enabled. The honest signal is the
+              # DOCKER-USER packet counters logged below: a rule matching nothing stays at
+              # zero. Revisit if CONTAINER_NETWORK ever becomes settable here.
 
               nf=$(cat /proc/sys/net/bridge/bridge-nf-call-iptables 2>/dev/null || echo missing)
               if [ "$nf" != "1" ]; then

--- a/charts/daytona-region/tests/baselines/rendered-baseline.yaml
+++ b/charts/daytona-region/tests/baselines/rendered-baseline.yaml
@@ -6,7 +6,7 @@ metadata:
   name: release-name-daytona-region-proxy
   namespace: default
   labels:
-    helm.sh/chart: daytona-region-0.2.2
+    helm.sh/chart: daytona-region-0.2.3
     app.kubernetes.io/name: daytona-region
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "v0.207.0"
@@ -21,7 +21,7 @@ metadata:
   name: release-name-daytona-region-runnermanager
   namespace: default
   labels:
-    helm.sh/chart: daytona-region-0.2.2
+    helm.sh/chart: daytona-region-0.2.3
     app.kubernetes.io/name: daytona-region
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "v0.207.0"
@@ -36,7 +36,7 @@ metadata:
   name: release-name-daytona-region-runner
   namespace: default
   labels:
-    helm.sh/chart: daytona-region-0.2.2
+    helm.sh/chart: daytona-region-0.2.3
     app.kubernetes.io/name: daytona-region
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "v0.207.0"
@@ -51,7 +51,7 @@ metadata:
   name: release-name-daytona-region-ssh-gateway
   namespace: default
   labels:
-    helm.sh/chart: daytona-region-0.2.2
+    helm.sh/chart: daytona-region-0.2.3
     app.kubernetes.io/name: daytona-region
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "v0.207.0"
@@ -66,7 +66,7 @@ metadata:
   name: release-name-daytona-region-runner-secrets
   namespace: default
   labels:
-    helm.sh/chart: daytona-region-0.2.2
+    helm.sh/chart: daytona-region-0.2.3
     app.kubernetes.io/name: daytona-region
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "v0.207.0"
@@ -92,7 +92,7 @@ metadata:
   name: release-name-daytona-region-secret-ssh
   namespace: default
   labels:
-    helm.sh/chart: daytona-region-0.2.2
+    helm.sh/chart: daytona-region-0.2.3
     app.kubernetes.io/name: daytona-region
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "v0.207.0"
@@ -112,7 +112,7 @@ metadata:
   name: release-name-daytona-region-runner-config
   namespace: default
   labels:
-    helm.sh/chart: daytona-region-0.2.2
+    helm.sh/chart: daytona-region-0.2.3
     app.kubernetes.io/name: daytona-region
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "v0.207.0"
@@ -146,7 +146,7 @@ metadata:
   name: release-name-daytona-region-runner-docker-installer-config
   namespace: default
   labels:
-    helm.sh/chart: daytona-region-0.2.2
+    helm.sh/chart: daytona-region-0.2.3
     app.kubernetes.io/name: daytona-region
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "v0.207.0"
@@ -163,7 +163,7 @@ kind: ClusterRole
 metadata:
   name: release-name-daytona-region-runner-manager-nodes
   labels:
-    helm.sh/chart: daytona-region-0.2.2
+    helm.sh/chart: daytona-region-0.2.3
     app.kubernetes.io/name: daytona-region
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "v0.207.0"
@@ -181,7 +181,7 @@ kind: ClusterRoleBinding
 metadata:
   name: release-name-daytona-region-runner-manager-nodes
   labels:
-    helm.sh/chart: daytona-region-0.2.2
+    helm.sh/chart: daytona-region-0.2.3
     app.kubernetes.io/name: daytona-region
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "v0.207.0"
@@ -204,7 +204,7 @@ metadata:
   name: release-name-daytona-region-runnermanager
   namespace: default
   labels:
-    helm.sh/chart: daytona-region-0.2.2
+    helm.sh/chart: daytona-region-0.2.3
     app.kubernetes.io/name: daytona-region
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "v0.207.0"
@@ -229,7 +229,7 @@ metadata:
   name: release-name-daytona-region-runnermanager
   namespace: default
   labels:
-    helm.sh/chart: daytona-region-0.2.2
+    helm.sh/chart: daytona-region-0.2.3
     app.kubernetes.io/name: daytona-region
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "v0.207.0"
@@ -252,7 +252,7 @@ metadata:
   namespace: default
   name: release-name-daytona-region-proxy
   labels:
-    helm.sh/chart: daytona-region-0.2.2
+    helm.sh/chart: daytona-region-0.2.3
     app.kubernetes.io/name: daytona-region
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "v0.207.0"
@@ -278,7 +278,7 @@ metadata:
   name: release-name-daytona-region-runnermanager
   namespace: default
   labels:
-    helm.sh/chart: daytona-region-0.2.2
+    helm.sh/chart: daytona-region-0.2.3
     app.kubernetes.io/name: daytona-region
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "v0.207.0"
@@ -304,7 +304,7 @@ metadata:
   name: release-name-daytona-region-ssh-gateway
   namespace: default
   labels:
-    helm.sh/chart: daytona-region-0.2.2
+    helm.sh/chart: daytona-region-0.2.3
     app.kubernetes.io/name: daytona-region
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "v0.207.0"
@@ -330,7 +330,7 @@ metadata:
   name: release-name-daytona-region-runner
   namespace: default
   labels:
-    helm.sh/chart: daytona-region-0.2.2
+    helm.sh/chart: daytona-region-0.2.3
     app.kubernetes.io/name: daytona-region
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "v0.207.0"
@@ -682,13 +682,18 @@ spec:
                 
                 # Write Docker daemon config with Sysbox runtime
                 # Note: Not including storage-driver to avoid conflicts with GKE systemd flags
-                # icc=false denies container-to-container traffic on the default bridge.
-                # It only takes effect on a daemon start with no running containers: moby skips
-                # configureNetworking when live-restore hands it active sandboxes, so on an
-                # in-place upgrade this key is inert and docker0 keeps EnableICC=true from the
-                # bridge store. Peer denial therefore does NOT rest on this key -- see the
-                # DOCKER-USER rule asserted by ensure_sandbox_peer_denial below, which needs no
-                # daemon restart. This key covers freshly provisioned nodes.
+                # icc=false does two things, neither of which is the whole control.
+                # 1. It makes moby load br_netfilter and set bridge-nf-call-iptables=1
+                #    (moby libnetwork/drivers/bridge/bridge_linux.go:849-851), which is the
+                #    precondition the DOCKER-USER rule needs to see same-bridge traffic at all.
+                # 2. It installs moby's own FORWARD drop before any pod schedules, which covers
+                #    the boot window the DaemonSet cannot.
+                # Both only happen on a daemon start with no running containers: moby skips
+                # configureNetworking when live-restore hands it active sandboxes
+                # (daemon/daemon_unix.go:848-850), so on an in-place upgrade this key is inert.
+                # daytona-peer-denial.sh therefore asserts the same precondition itself and
+                # carries the running population.
+                # NOTE: changing this file makes the installer restart dockerd once per node.
                 cat > /etc/docker/daemon.json << 'DOCKERCONFIG'
               {
                 "runtimes": {
@@ -722,30 +727,71 @@ spec:
               
               # Configure Docker to use Sysbox
               configure_docker_sysbox
-              
-              # Start Sysbox services
-              # Deny traffic between unrelated sandboxes on the default bridge.
+              # Single-source the peer-denial logic to a host script. The bootstrap heredoc and
+              # the monitor loop run in separate shells and cannot share a function, and an
+              # inline copy in each has already been observed to drift.
+              cat > /usr/local/sbin/daytona-peer-denial.sh << 'PEERDENIAL'
+              #!/bin/sh
+              # Deny traffic between unrelated sandboxes on the host default bridge.
               #
-              # This is the control that actually holds. It lives in DOCKER-USER, which docker
-              # never flushes, so it survives a dockerd restart and -- unlike the icc key -- it
-              # applies immediately to sandboxes that are already running.
+              # Scope: exactly one topology -- sandboxes on docker0. It does not apply when
+              # CONTAINER_NETWORK puts sandboxes on a br-<id> bridge.
               #
-              # Anchored on -i docker0 -o docker0, so it matches only same-bridge peer traffic.
-              # Deliberately linked sandboxes are unaffected: the runner puts them on their own
-              # link bridge and anchors its ACCEPT rules to that interface, so the two rules can
-              # never match the same packet and their relative order does not matter.
+              # Contract with linked sandboxes: both peers hold a docker0 endpoint AND a link
+              # endpoint. DNS by name and by sandbox id resolves to the link address, so linked
+              # traffic is unaffected. Traffic addressed to a peer's raw docker0 address IS
+              # denied -- intentionally, since an interface matcher cannot tell it apart from
+              # unrelated-tenant traffic.
               #
-              # Check-then-insert: a bare -I on a 60s reconcile stacks a duplicate every pass.
-              ensure_sandbox_peer_denial() {
-                iptables -w -C DOCKER-USER -i docker0 -o docker0 -j DROP 2>/dev/null \
-                  || iptables -w -I DOCKER-USER 1 -i docker0 -o docker0 -j DROP
-                # Best effort: only reachable if the operator enabled IPv6 on the bridge.
-                if command -v ip6tables >/dev/null 2>&1; then
-                  ip6tables -w -C DOCKER-USER -i docker0 -o docker0 -j DROP 2>/dev/null \
-                    || ip6tables -w -I DOCKER-USER 1 -i docker0 -o docker0 -j DROP 2>/dev/null || true
-                fi
-              }
+              # Invariant: nothing above this rule in DOCKER-USER may ACCEPT sandbox peer
+              # traffic. The runner anchors its link ACCEPTs to -i <link-bridge> for exactly
+              # this reason (apps/runner/pkg/netrules/link_icc.go); keep it that way.
+              set -u
+              rc=0
 
+              # Kernel precondition. Same-bridge frames are switched at L2 and reach iptables
+              # only when br_netfilter is loaded with bridge-nf-call-iptables=1. Docker
+              # provisions this itself when icc=false, but only on a daemon start with no
+              # running containers -- so on an in-place upgrade it is absent and the rule below
+              # would install cleanly and filter nothing. Assert it here and read it back.
+              modprobe br_netfilter 2>/dev/null || true
+              echo 1 > /proc/sys/net/bridge/bridge-nf-call-iptables 2>/dev/null || true
+              echo 1 > /proc/sys/net/bridge/bridge-nf-call-ip6tables 2>/dev/null || true
+              echo br_netfilter > /etc/modules-load.d/daytona-sandbox-isolation.conf 2>/dev/null || true
+              printf 'net.bridge.bridge-nf-call-iptables = 1\nnet.bridge.bridge-nf-call-ip6tables = 1\n' \
+                > /etc/sysctl.d/99-daytona-sandbox-isolation.conf 2>/dev/null || true
+              nf=$(cat /proc/sys/net/bridge/bridge-nf-call-iptables 2>/dev/null || echo missing)
+              if [ "$nf" != "1" ]; then
+                echo "ERROR: bridge-nf-call-iptables=$nf -- the peer-denial rule will NOT filter same-bridge traffic on this node"
+                rc=1
+              fi
+
+              # Check-then-insert: a bare -I on a reconcile stacks a duplicate every pass.
+              if ! iptables -w -C DOCKER-USER -i docker0 -o docker0 -j DROP 2>/dev/null; then
+                if iptables -w -I DOCKER-USER 1 -i docker0 -o docker0 -j DROP; then
+                  echo "Installed IPv4 sandbox peer-denial rule"
+                else
+                  echo "ERROR: failed to install IPv4 sandbox peer-denial rule"
+                  rc=1
+                fi
+              fi
+
+              # ip6tables defaults on from Docker 27.4.1, so this chain exists. Non-fatal, but
+              # never silent: containers can hold IPv6 addresses and sandbox services bind ::.
+              if ! ip6tables -w -C DOCKER-USER -i docker0 -o docker0 -j DROP 2>/dev/null; then
+                if ip6tables -w -I DOCKER-USER 1 -i docker0 -o docker0 -j DROP 2>/dev/null; then
+                  echo "Installed IPv6 sandbox peer-denial rule"
+                else
+                  echo "WARNING: failed to install IPv6 sandbox peer-denial rule; IPv6 peer traffic is not denied"
+                fi
+              fi
+
+              exit $rc
+              PEERDENIAL
+              sed -i 's/^              //' /usr/local/sbin/daytona-peer-denial.sh
+              chmod 0755 /usr/local/sbin/daytona-peer-denial.sh
+
+              # Start Sysbox services
               echo "Starting Sysbox services..."
               systemctl enable sysbox 2>/dev/null || true
               systemctl start sysbox 2>/dev/null || true
@@ -770,10 +816,10 @@ spec:
               else
                 echo "Docker already running with Sysbox runtime and unchanged config; skipping restart to avoid disrupting running sandboxes"
               fi
-              
               # Assert peer denial now that dockerd is up and DOCKER-USER exists.
-              echo "Asserting sandbox peer-denial rule..."
-              ensure_sandbox_peer_denial || echo "WARNING: failed to assert sandbox peer-denial rule"
+              echo "Asserting sandbox peer-denial..."
+              /usr/local/sbin/daytona-peer-denial.sh \
+                || echo "WARNING: sandbox peer-denial assert FAILED -- peers may be reachable on this node"
 
               # Verify installation
               echo "=== Verification ==="
@@ -799,17 +845,20 @@ spec:
                     systemctl start sysbox 2>/dev/null || echo "Failed to start Sysbox"
                   fi
                   
-                  # Check Docker
+                  # Check Docker. Each check reports its own failure: the payload exit
+                  # status is fixed at 0 below, so no later command can mask an earlier one.
                   if ! systemctl is-active --quiet docker; then
                     echo "Docker service is down, restarting..."
-                    systemctl start docker
+                    systemctl start docker || echo "Failed to start Docker"
                   fi
 
                   # Re-assert sandbox peer denial. DOCKER-USER survives a dockerd restart, but
                   # re-check anyway: an operator iptables flush would otherwise silently reopen
                   # peer reachability until the next pod start.
-                  iptables -w -C DOCKER-USER -i docker0 -o docker0 -j DROP 2>/dev/null \
-                    || iptables -w -I DOCKER-USER 1 -i docker0 -o docker0 -j DROP
+                  /usr/local/sbin/daytona-peer-denial.sh \
+                    || echo "WARNING: sandbox peer-denial re-assert FAILED"
+
+                  exit 0
                 ' || echo "Health check failed, will retry..."
                 sleep 60
               done
@@ -983,7 +1032,7 @@ metadata:
   namespace: default
   name: release-name-daytona-region-proxy
   labels:
-    helm.sh/chart: daytona-region-0.2.2
+    helm.sh/chart: daytona-region-0.2.3
     app.kubernetes.io/name: daytona-region
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "v0.207.0"
@@ -1058,7 +1107,7 @@ metadata:
   namespace: default
   name: release-name-daytona-region-runnermanager
   labels:
-    helm.sh/chart: daytona-region-0.2.2
+    helm.sh/chart: daytona-region-0.2.3
     app.kubernetes.io/name: daytona-region
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "v0.207.0"
@@ -1177,7 +1226,7 @@ metadata:
   name: release-name-daytona-region-ssh-gateway
   namespace: default
   labels:
-    helm.sh/chart: daytona-region-0.2.2
+    helm.sh/chart: daytona-region-0.2.3
     app.kubernetes.io/name: daytona-region
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "v0.207.0"
@@ -1241,7 +1290,7 @@ metadata:
   name: release-name-daytona-region-proxy
   namespace: default
   labels:
-    helm.sh/chart: daytona-region-0.2.2
+    helm.sh/chart: daytona-region-0.2.3
     app.kubernetes.io/name: daytona-region
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "v0.207.0"
@@ -1288,7 +1337,7 @@ metadata:
   name: release-name-daytona-region-region-registration
   namespace: default
   labels:
-    helm.sh/chart: daytona-region-0.2.2
+    helm.sh/chart: daytona-region-0.2.3
     app.kubernetes.io/name: daytona-region
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "v0.207.0"
@@ -1307,7 +1356,7 @@ metadata:
   name: release-name-daytona-region-daytona-api-key
   namespace: default
   labels:
-    helm.sh/chart: daytona-region-0.2.2
+    helm.sh/chart: daytona-region-0.2.3
     app.kubernetes.io/name: daytona-region
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "v0.207.0"
@@ -1331,7 +1380,7 @@ metadata:
   name: release-name-daytona-region-region-registration
   namespace: default
   labels:
-    helm.sh/chart: daytona-region-0.2.2
+    helm.sh/chart: daytona-region-0.2.3
     app.kubernetes.io/name: daytona-region
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "v0.207.0"
@@ -1354,7 +1403,7 @@ metadata:
   name: release-name-daytona-region-region-registration
   namespace: default
   labels:
-    helm.sh/chart: daytona-region-0.2.2
+    helm.sh/chart: daytona-region-0.2.3
     app.kubernetes.io/name: daytona-region
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "v0.207.0"
@@ -1381,7 +1430,7 @@ metadata:
   name: release-name-daytona-region-region-registration
   namespace: default
   labels:
-    helm.sh/chart: daytona-region-0.2.2
+    helm.sh/chart: daytona-region-0.2.3
     app.kubernetes.io/name: daytona-region
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "v0.207.0"
@@ -1430,7 +1479,7 @@ spec:
                 name: release-name-daytona-region-region-config
                 namespace: default
                 labels:
-                  helm.sh/chart: daytona-region-0.2.2
+                  helm.sh/chart: daytona-region-0.2.3
                   app.kubernetes.io/name: daytona-region
                   app.kubernetes.io/instance: release-name
                   app.kubernetes.io/version: "v0.207.0"

--- a/charts/daytona-region/tests/baselines/rendered-baseline.yaml
+++ b/charts/daytona-region/tests/baselines/rendered-baseline.yaml
@@ -776,13 +776,16 @@ spec:
                 fi
               fi
 
-              # ip6tables defaults on from Docker 27.4.1, so this chain exists. Non-fatal, but
-              # never silent: containers can hold IPv6 addresses and sandbox services bind ::.
+              # ip6tables defaults on from Docker 27.4.1 (cmd/dockerd/config_unix.go:31), so this
+              # chain exists on every node this chart provisions and a failure here is a real
+              # gap, not an absent feature: containers can hold IPv6 addresses and sandbox
+              # services bind ::. Counts toward the exit status.
               if ! ip6tables -w -C DOCKER-USER -i docker0 -o docker0 -j DROP 2>/dev/null; then
-                if ip6tables -w -I DOCKER-USER 1 -i docker0 -o docker0 -j DROP 2>/dev/null; then
+                if ip6tables -w -I DOCKER-USER 1 -i docker0 -o docker0 -j DROP; then
                   echo "Installed IPv6 sandbox peer-denial rule"
                 else
-                  echo "WARNING: failed to install IPv6 sandbox peer-denial rule; IPv6 peer traffic is not denied"
+                  echo "ERROR: failed to install IPv6 sandbox peer-denial rule; IPv6 peer traffic is NOT denied"
+                  rc=1
                 fi
               fi
 
@@ -817,9 +820,19 @@ spec:
                 echo "Docker already running with Sysbox runtime and unchanged config; skipping restart to avoid disrupting running sandboxes"
               fi
               # Assert peer denial now that dockerd is up and DOCKER-USER exists.
+              #
+              # FAIL CLOSED. If isolation is enabled and cannot be established, this container
+              # exits non-zero rather than leaving the node running while values claim peers
+              # are denied. The node becomes visibly broken instead of quietly unprotected.
+              #
+              # Limit worth knowing: in the runner-manager topology this DaemonSet only
+              # bootstraps the node, so a crash here does not by itself stop sandboxes being
+              # placed on it. Blocking admission requires the runner-side health probe.
               echo "Asserting sandbox peer-denial..."
-              /usr/local/sbin/daytona-peer-denial.sh \
-                || echo "WARNING: sandbox peer-denial assert FAILED -- peers may be reachable on this node"
+              if ! /usr/local/sbin/daytona-peer-denial.sh; then
+                echo "FATAL: sandbox peer-denial could not be established; refusing to report this node healthy"
+                exit 1
+              fi
 
               # Verify installation
               echo "=== Verification ==="
@@ -855,11 +868,22 @@ spec:
                   # Re-assert sandbox peer denial. DOCKER-USER survives a dockerd restart, but
                   # re-check anyway: an operator iptables flush would otherwise silently reopen
                   # peer reachability until the next pod start.
-                  /usr/local/sbin/daytona-peer-denial.sh \
-                    || echo "WARNING: sandbox peer-denial re-assert FAILED"
+                  #
+                  # Fail closed: exit non-zero so the container restarts and re-runs the full
+                  # bootstrap assert, rather than looping forever on an unprotected node.
+                  if ! /usr/local/sbin/daytona-peer-denial.sh; then
+                    echo "FATAL: sandbox peer-denial re-assert failed"
+                    exit 1
+                  fi
 
                   exit 0
-                ' || echo "Health check failed, will retry..."
+                ' || { rc=$?
+                  if [ "$rc" = 1 ]; then
+                    echo "Sandbox peer-denial enforcement lost; exiting so the container restarts"
+                    exit 1
+                  fi
+                  echo "Health check failed, will retry..."
+                }
                 sleep 60
               done
               ln -s /host/var/lib/docker /var/lib/docker

--- a/charts/daytona-region/tests/runner-sandbox-hardening_test.yaml
+++ b/charts/daytona-region/tests/runner-sandbox-hardening_test.yaml
@@ -72,6 +72,26 @@ tests:
           path: spec.template.spec.containers[0].args[0]
           pattern: '"icc": false'
 
+  - it: does not bounce dockerd for the icc key alone
+    set:
+      regionName: "test"
+      proxyUrl: "https://p.example.com"
+      daytonaApiUrl: "https://api.example.com/api"
+      daytonaApiKey: "test"
+    asserts:
+      # The restart decision compares daemon.json with the icc key filtered out, so
+      # adding it never stops a running sandbox to apply a key that is inert there.
+      - matchRegex:
+          path: spec.template.spec.containers[0].args[0]
+          pattern: "grep -v '\"icc\"' /etc/docker/daemon.json > /tmp/daytona-dj-new"
+      - matchRegex:
+          path: spec.template.spec.containers[0].args[0]
+          pattern: 'elif \[ "\$daemon_json_changed" = 1 \]'
+      # Bounded xtables wait: the runner writes DOCKER-USER on every sandbox change.
+      - matchRegex:
+          path: spec.template.spec.containers[0].args[0]
+          pattern: 'iptables -w 5 -I DOCKER-USER 1 -i docker0'
+
   - it: fails closed when peer denial cannot be established
     set:
       regionName: "test"

--- a/charts/daytona-region/tests/runner-sandbox-hardening_test.yaml
+++ b/charts/daytona-region/tests/runner-sandbox-hardening_test.yaml
@@ -72,6 +72,25 @@ tests:
           path: spec.template.spec.containers[0].args[0]
           pattern: '"icc": false'
 
+  - it: fails closed when peer denial cannot be established
+    set:
+      regionName: "test"
+      proxyUrl: "https://p.example.com"
+      daytonaApiUrl: "https://api.example.com/api"
+      daytonaApiKey: "test"
+    asserts:
+      # Bootstrap and monitor loop both exit non-zero rather than warn and continue.
+      - matchRegex:
+          path: spec.template.spec.containers[0].args[0]
+          pattern: '(?s)FATAL: sandbox peer-denial could not be established.*?exit 1'
+      - matchRegex:
+          path: spec.template.spec.containers[0].args[0]
+          pattern: '(?s)FATAL: sandbox peer-denial re-assert failed.*?exit 1'
+      # IPv6 insertion failure counts toward the exit status, not a bare warning.
+      - matchRegex:
+          path: spec.template.spec.containers[0].args[0]
+          pattern: '(?s)ERROR: failed to install IPv6 sandbox peer-denial rule[^\n]*\n\s*rc=1'
+
   - it: removes the peer-denial rule when sandboxIsolation is disabled
     set:
       regionName: "test"
@@ -239,3 +258,15 @@ tests:
           content:
             name: volume-mount-shim
           any: true
+
+  - it: rejects isolation enabled without the docker installer
+    set:
+      regionName: "test"
+      proxyUrl: "https://p.example.com"
+      daytonaApiUrl: "https://api.example.com/api"
+      daytonaApiKey: "test"
+      services.runner.sandboxIsolation.enabled: true
+      services.runner.dockerInstaller.enabled: false
+    asserts:
+      - failedTemplate:
+          errorMessage: "services.runner.sandboxIsolation.enabled=true requires services.runner.dockerInstaller.enabled=true (the peer-denial control is applied by the docker-installer). Set services.runner.sandboxIsolation.enabled=false to run without inter-sandbox isolation, and provide an equivalent host-level control yourself."

--- a/charts/daytona-region/tests/runner-sandbox-hardening_test.yaml
+++ b/charts/daytona-region/tests/runner-sandbox-hardening_test.yaml
@@ -32,32 +32,64 @@ tests:
           path: spec.template.spec.containers[0].args[0]
           pattern: buildkitd\.toml
 
-  # NOTE: a render assertion proves the text is emitted, NOT that peer traffic is
-  # denied on a node. The property is proven only by a live two-sandbox probe plus
-  # captured kernel state; see the peer-denial validation runbook.
-  - it: asserts sandbox peer denial by default, without depending on a daemon restart
+  # NOTE: these prove the text is emitted, NOT that peer traffic is denied on a
+  # node. The property is proven only by a live two-sandbox probe with captured
+  # kernel state. Assertions target executable statements, never comments.
+  - it: asserts sandbox peer denial by default
     set:
       regionName: "test"
       proxyUrl: "https://p.example.com"
       daytonaApiUrl: "https://api.example.com/api"
       daytonaApiKey: "test"
     asserts:
-      # The reconciled DOCKER-USER rule is the control that holds.
+      # Single-sourced host script, so the two call sites cannot drift.
+      - matchRegex:
+          path: spec.template.spec.containers[0].args[0]
+          pattern: 'cat > /usr/local/sbin/daytona-peer-denial\.sh'
+      # Invoked at bootstrap AND from the monitor loop.
+      - matchRegex:
+          path: spec.template.spec.containers[0].args[0]
+          pattern: '(?s)Asserting sandbox peer-denial\.\.\..*?/usr/local/sbin/daytona-peer-denial\.sh'
+      - matchRegex:
+          path: spec.template.spec.containers[0].args[0]
+          pattern: '(?s)Re-assert sandbox peer denial.*?/usr/local/sbin/daytona-peer-denial\.sh'
+      # The rule itself.
       - matchRegex:
           path: spec.template.spec.containers[0].args[0]
           pattern: 'iptables -w -I DOCKER-USER 1 -i docker0 -o docker0 -j DROP'
-      # Asserted during bootstrap ...
       - matchRegex:
           path: spec.template.spec.containers[0].args[0]
-          pattern: 'ensure_sandbox_peer_denial'
-      # ... and re-asserted by the monitor loop, so an iptables flush self-heals.
+          pattern: 'ip6tables -w -I DOCKER-USER 1 -i docker0 -o docker0 -j DROP'
+      # The kernel precondition, without which the rule filters nothing.
       - matchRegex:
           path: spec.template.spec.containers[0].args[0]
-          pattern: 'Re-assert sandbox peer denial'
-      # Belt and braces for freshly provisioned nodes only.
+          pattern: 'modprobe br_netfilter'
+      - matchRegex:
+          path: spec.template.spec.containers[0].args[0]
+          pattern: 'bridge-nf-call-iptables'
+      # Boot-window coverage.
       - matchRegex:
           path: spec.template.spec.containers[0].args[0]
           pattern: '"icc": false'
+
+  - it: removes the peer-denial rule when sandboxIsolation is disabled
+    set:
+      regionName: "test"
+      proxyUrl: "https://p.example.com"
+      daytonaApiUrl: "https://api.example.com/api"
+      daytonaApiKey: "test"
+      services.runner.sandboxIsolation.enabled: false
+    asserts:
+      # No enforcement, and no orphaned rule left behind.
+      - notMatchRegex:
+          path: spec.template.spec.containers[0].args[0]
+          pattern: 'iptables -w -I DOCKER-USER 1 -i docker0 -o docker0 -j DROP'
+      - notMatchRegex:
+          path: spec.template.spec.containers[0].args[0]
+          pattern: '"icc": false'
+      - matchRegex:
+          path: spec.template.spec.containers[0].args[0]
+          pattern: 'iptables -w -D DOCKER-USER -i docker0 -o docker0 -j DROP'
 
   - it: networkPolicy.enabled renders the egress-enforcer with block + input rules
     set:

--- a/charts/daytona-region/tests/runner-sandbox-hardening_test.yaml
+++ b/charts/daytona-region/tests/runner-sandbox-hardening_test.yaml
@@ -82,7 +82,11 @@ tests:
       # Bootstrap and monitor loop both exit non-zero rather than warn and continue.
       - matchRegex:
           path: spec.template.spec.containers[0].args[0]
-          pattern: '(?s)FATAL: sandbox peer-denial could not be established.*?exit 1'
+          pattern: '(?s)FATAL: sandbox peer-denial could not be established.*?exit 3'
+      # ...and that inner exit must reach the outer shell, not die inside nsenter.
+      - matchRegex:
+          path: spec.template.spec.containers[0].args[0]
+          pattern: '(?s)bootstrap_rc=\$\?.*?bootstrap_rc" = 3.*?exit 1'
       - matchRegex:
           path: spec.template.spec.containers[0].args[0]
           pattern: '(?s)FATAL: sandbox peer-denial re-assert failed.*?exit 1'
@@ -270,3 +274,16 @@ tests:
     asserts:
       - failedTemplate:
           errorMessage: "services.runner.sandboxIsolation.enabled=true requires services.runner.dockerInstaller.enabled=true (the peer-denial control is applied by the docker-installer). Set services.runner.sandboxIsolation.enabled=false to run without inter-sandbox isolation, and provide an equivalent host-level control yourself."
+
+  - it: does not reject the config when no runner is deployed
+    set:
+      regionName: "test"
+      proxyUrl: "https://p.example.com"
+      daytonaApiUrl: "https://api.example.com/api"
+      daytonaApiKey: "test"
+      services.runner.enabled: false
+      services.runner.sandboxIsolation.enabled: true
+      services.runner.dockerInstaller.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/charts/daytona-region/tests/runner-sandbox-hardening_test.yaml
+++ b/charts/daytona-region/tests/runner-sandbox-hardening_test.yaml
@@ -32,6 +32,33 @@ tests:
           path: spec.template.spec.containers[0].args[0]
           pattern: buildkitd\.toml
 
+  # NOTE: a render assertion proves the text is emitted, NOT that peer traffic is
+  # denied on a node. The property is proven only by a live two-sandbox probe plus
+  # captured kernel state; see the peer-denial validation runbook.
+  - it: asserts sandbox peer denial by default, without depending on a daemon restart
+    set:
+      regionName: "test"
+      proxyUrl: "https://p.example.com"
+      daytonaApiUrl: "https://api.example.com/api"
+      daytonaApiKey: "test"
+    asserts:
+      # The reconciled DOCKER-USER rule is the control that holds.
+      - matchRegex:
+          path: spec.template.spec.containers[0].args[0]
+          pattern: 'iptables -w -I DOCKER-USER 1 -i docker0 -o docker0 -j DROP'
+      # Asserted during bootstrap ...
+      - matchRegex:
+          path: spec.template.spec.containers[0].args[0]
+          pattern: 'ensure_sandbox_peer_denial'
+      # ... and re-asserted by the monitor loop, so an iptables flush self-heals.
+      - matchRegex:
+          path: spec.template.spec.containers[0].args[0]
+          pattern: 'Re-assert sandbox peer denial'
+      # Belt and braces for freshly provisioned nodes only.
+      - matchRegex:
+          path: spec.template.spec.containers[0].args[0]
+          pattern: '"icc": false'
+
   - it: networkPolicy.enabled renders the egress-enforcer with block + input rules
     set:
       regionName: "test"

--- a/charts/daytona-region/values.yaml
+++ b/charts/daytona-region/values.yaml
@@ -666,8 +666,8 @@ services:
     # On by default. Disabling it removes the rule from every node on the next
     # roll -- sandboxes on a node can then reach each other's internal services.
     #
-    # Only covers sandboxes on the default bridge; it does not apply when
-    # CONTAINER_NETWORK places sandboxes on a user-defined bridge.
+    # Only covers sandboxes on the default bridge, which is what this chart
+    # produces. It would not apply if sandboxes were placed on another bridge.
     #
     # Toggling this changes the host daemon.json and so restarts dockerd once per
     # node. With dockerInstaller.liveRestore true (default) running sandboxes

--- a/charts/daytona-region/values.yaml
+++ b/charts/daytona-region/values.yaml
@@ -659,6 +659,21 @@ services:
     # every reconcileSeconds. Return traffic of runner->sandbox connections
     # is always allowed (conntrack), and dockerInstaller.dns entries are
     # automatically exempted so DNS hardening cannot be broken by the policy.
+    # Deny network traffic between unrelated sandboxes that are co-resident on a
+    # runner node. Enforced by a DOCKER-USER rule anchored on the host default
+    # bridge, re-asserted every 60s, plus "icc": false in the host daemon.json.
+    #
+    # On by default. Disabling it removes the rule from every node on the next
+    # roll -- sandboxes on a node can then reach each other's internal services.
+    #
+    # Only covers sandboxes on the default bridge; it does not apply when
+    # CONTAINER_NETWORK places sandboxes on a user-defined bridge.
+    #
+    # Toggling this changes the host daemon.json and so restarts dockerd once per
+    # node. With dockerInstaller.liveRestore true (default) running sandboxes
+    # survive that restart; with it false they are stopped.
+    sandboxIsolation:
+      enabled: true
     networkPolicy:
       enabled: false
       # blocklist: allow all sandbox egress EXCEPT blockCIDRs/blockHostPorts.


### PR DESCRIPTION
Sandboxes attach to the host default bridge, which permits container-to-container traffic. This denies it by default.

## The control

A single host script, `daytona-peer-denial.sh`, asserted at bootstrap once dockerd is up and re-asserted by the installer's existing 60s monitor loop. It:

1. **Establishes the kernel precondition.** Same-bridge frames are switched at L2 and reach iptables only when `br_netfilter` is loaded with `bridge-nf-call-iptables=1`. moby provisions that itself when `icc=false` (`libnetwork/drivers/bridge/bridge_linux.go:849-851`), but only inside `createNetwork`, which `daemon/daemon_unix.go:848-850` skips when live-restore hands the daemon running containers. On an in-place upgrade it is therefore absent, and a DOCKER-USER rule would install cleanly while filtering nothing. The script loads the module, sets and persists both sysctls, and reads the value back.
2. **Installs `-i docker0 -o docker0 -j DROP`** in DOCKER-USER, IPv4 and IPv6, check-then-insert, with a bounded `-w 5`.

`DOCKER-USER` is never flushed by docker, so the rule survives a daemon restart, applies to sandboxes already running, and self-heals if the host ruleset is flushed.

`"icc": false` is retained and gated with the control, for the precondition above and for boot-window coverage: every reboot is a zero-sandbox daemon start, so moby installs its own FORWARD drop before this DaemonSet schedules. **It does not trigger a dockerd restart** — see below.

## Why the host rule rather than `INTER_SANDBOX_NETWORK_ENABLED=false`

The runner already supports placing sandboxes on a dedicated `runner-bridge` with `enable_icc=false`. That is the better long-term shape and is tracked separately, but it cannot be the control here:

- **It is not reachable through the chart.** `runner-configmap.yaml` is a fixed key allowlist carrying neither that variable nor `CONTAINER_NETWORK`, and `services.runner.extraEnv` renders only when `mainContainer.enabled` is true, which is not the topology BYOC regions run. Verified by render: zero occurrences under default values.
- **It protects nothing already running.** Network attachment is decided at container create, so existing sandboxes stay on `docker0` and stay mutually reachable until each is recreated. Sandboxes are persistent by default. The DOCKER-USER rule applies to the current population immediately.
- **The subnet is hardcoded.** `client.go:148` pins `172.20.0.0/16`, which AWS assigns as one of two default EKS service CIDRs. moby's static-subnet path does not consult host routes, so the network is created and the node gains an on-link route over the cluster service CIDR; with concurrent link networks it hits `ErrPoolOverlap` and the runner exits.
- **It depends on the runner image.** Operators pinned to an older runner tag would not get it. A chart-side rule covers them, and covers any container on the bridge the runner did not create.

## Contract

```
sandboxIsolation.enabled: false  -> intentional operator opt-out
sandboxIsolation.enabled: true   -> enforced, or the container fails closed
dockerInstaller.enabled          -> controls Docker/Sysbox installation only
```

`services.runner.sandboxIsolation.enabled` defaults to `true`. Disabling it removes the rules, the script, the sysctl drop-in and the modules-load drop-in rather than orphaning them.

The peer-denial control is applied by the docker-installer container, so it cannot be rendered without it. `sandboxIsolation.enabled: true` with `dockerInstaller.enabled: false` is rejected at template time rather than silently shipping a runner with no isolation. The guard is scoped to runner-enabled installs.

## No dockerd restart

Adding the icc key used to make `daemon.json` differ from its `.bak`, tripping `need_restart`. That restart never paid for itself: with `liveRestore: true` (default) the sandboxes survive and moby skips `configureNetworking`, so the key stays inert; with it false the key applies but every sandbox on the node is stopped to get there. The DOCKER-USER rule already covers both cases.

The restart comparison now filters the icc key out of both files. The key still lands in `daemon.json` and applies at the next natural restart, which is a reboot or a fresh node. A genuine change such as `dns` or `insecure-registries` still triggers a restart.

Trade-off: turning `sandboxIsolation` off no longer fully applies until dockerd restarts, because moby's own block lingers on nodes where it was ever installed. That errs toward more isolation, not less.

## Fail closed

Enforcement failure exits non-zero at both call sites. IPv4 and IPv6 insertion failures are both fatal — ip6tables defaults on from Docker 27.4.1 (`cmd/dockerd/config_unix.go:31`), so that chain exists on every node this chart provisions.

The bootstrap failure exits with a distinct code that the outer shell propagates, because the inner `exit` happens inside `nsenter` and would otherwise be swallowed. The code is distinct deliberately: the surrounding bootstrap script was never written to be exit-status clean, and gating the container on its overall status would crash nodes for unrelated reasons.

**Known limit.** In the runner-manager topology this DaemonSet only bootstraps the node, so failing closed makes the node visibly broken but does not by itself stop sandboxes being placed on it. Closing that requires a runner-side isolation probe feeding `serviceHealth`, consumed by the existing `SERVICE_BLOCKS` / `runnerAllows(..., 'create')` gate. That is internal runner work, tracked separately.

## Upgrade notes

- **Linked sandboxes lose IP-addressed traffic.** Both peers hold a docker0 endpoint and a link endpoint. DNS by name and by sandbox id resolves to the link address and is unaffected. Traffic sent to a peer's raw docker0 address is denied, intentionally, since an interface matcher cannot distinguish it from unrelated-tenant traffic.
- **Same-organization sandboxes on one node also lose peer reachability**, unless explicitly linked.
- **`dockerInstaller.enabled: false` now fails the render** if isolation is left enabled. Set `sandboxIsolation.enabled=false` explicitly to keep that configuration.
- **A node that cannot load `br_netfilter` now fails closed** rather than running unprotected.
- No dockerd restart is introduced by this change.

## Scope and limits

- Covers sandboxes on the default bridge only. It does not apply when `CONTAINER_NETWORK` places them on a user-defined bridge; the script logs a warning when `docker0` is absent so that case is visible rather than a silent success.
- Node-level; carries no organization or sandbox identity.
- Invariant: nothing above this rule in DOCKER-USER may ACCEPT sandbox peer traffic. The runner anchors its link ACCEPTs to `-i <link-bridge>` for exactly this reason.

## Validation

- Restart decision, exercised directly: adding the icc key alone gives no restart, removing it alone gives no restart, a `dns` change still gives one.
- Exit-status matrix over the generated script, dash and bash, iptables/ip6tables stubbed across all combinations: `rc=1` on every IPv4 failure, every IPv6 failure, and when iptables is absent from PATH; `rc=0` only when both succeed.
- Bootstrap propagation: the inner fail-closed exit reaches the outer shell rather than dying inside `nsenter`.
- Monitor-loop matrix: docker-down and peer-denial-failure each emit their own message and neither masks the other.
- Contract matrix across all four isolation/installer combinations, plus runner-disabled.
- `daemon.json` parses as valid JSON and the installer passes `sh -n` across six value permutations, including `sandboxIsolation.enabled=false` and airgapped.
- `scripts/_lib/check/check-baseline-compat.sh` passes.

Outstanding: a live two-sandbox probe on a real node, capturing `lsmod | grep br_netfilter`, both sysctls, and DOCKER-USER packet counters across a dockerd restart, a DaemonSet roll and a reboot, including a linked pair addressed by IP. Everything above is render-time or harness evidence; none of it proves a packet was dropped.
