### PR TITLE
chore(daytona-region): bump Sysbox to v0.7.1 and verify the package before install

### DIFF
--- a/charts/daytona-region/Chart.yaml
+++ b/charts/daytona-region/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: daytona-region
 description: A Helm chart for Daytona custom region
 type: application
-version: 0.2.3
+version: 0.2.4
 appVersion: "v0.207.0"
 keywords:
   - ai

--- a/charts/daytona-region/QUICKSTART.md
+++ b/charts/daytona-region/QUICKSTART.md
@@ -112,7 +112,7 @@ All available keys and their defaults live in [`charts/daytona-region/values.yam
 
 - `services.proxy.ingress.tls`, `services.proxy.ingress.selfSigned`, `services.proxy.ingress.certificate` — TLS setup for the proxy ingress.
 - `services.runner.daemonInstaller.enabled` — pre-installs the sandbox binaries onto each runner node. Keep enabled unless you manage those binaries out-of-band.
-- `services.runner.dockerInstaller.enabled` — installs Docker + Sysbox on the node. Disable if your node image already has them.
+- `services.runner.dockerInstaller.enabled` — installs Docker + Sysbox on the node. Disable if your node image already has them. The chart installs Sysbox **v0.7.1** (amd64 `.deb`, verified against the published sha256) onto Ubuntu 24.04 (noble) nodes — the same requirement the Docker install already has. A node that already has Sysbox keeps the version it was provisioned with — upgrading in place would stop dockerd and kill every sandbox on that node, so a newer pin is picked up by replacing nodes, not by re-running the installer.
 - `services.snapshotManager.*` — the region's snapshot registry. A region needs it (plus `snapshotManagerUrl`) before snapshots can be created in it. `storage.driver: s3` requires REAL S3 (AWS); for everything else use `storage.driver: filesystem` with the built-in PVC — S3 shims (rclone gateway, GCS interop) break the registry's multipart-upload resume path.
 
 ## 3. Install the chart

--- a/charts/daytona-region/templates/runner-daemonset.yaml
+++ b/charts/daytona-region/templates/runner-daemonset.yaml
@@ -254,35 +254,48 @@ spec:
               # Function to install Sysbox from offline packages
               install_sysbox() {
                 if command -v sysbox >/dev/null 2>&1 || [ -f /usr/bin/sysbox-runc ]; then
-                  echo "Sysbox is already installed"
+                  # Nodes keep the Sysbox they were provisioned with. Upgrading in place
+                  # means stopping dockerd, which kills every sandbox on the node; version
+                  # changes are picked up by replacing nodes, not by re-running this.
+                  echo "Sysbox is already installed; leaving it alone"
+                  /usr/bin/sysbox-runc --version 2>/dev/null || true
                   return 0
                 fi
-                
+
                 echo "Installing Sysbox from offline packages..."
-                
+
                 if [ ! -d "$PACKAGES_DIR/sysbox" ]; then
                   echo "ERROR: Sysbox packages directory not found at $PACKAGES_DIR/sysbox"
                   return 1
                 fi
-                
-                # Determine architecture
+
+                # This chart installs the amd64 package only.
                 ARCH=$(uname -m)
                 if [ "$ARCH" != "x86_64" ] && [ "$ARCH" != "amd64" ]; then
-                  echo "Sysbox only supports x86_64 architecture"
+                  echo "ERROR: this chart installs the amd64 Sysbox package only; node is ${ARCH}"
                   return 1
                 fi
-                
+
                 # Stop Docker before installing Sysbox
                 echo "Stopping Docker for Sysbox installation..."
                 systemctl stop docker 2>/dev/null || true
-                
+
                 # Install Sysbox package
                 echo "Installing Sysbox package..."
-                dpkg -i $PACKAGES_DIR/sysbox/sysbox-ce_*.deb || {
+                # dpkg's status is not the verdict here: the glob can match packages for
+                # other architectures shipped in the same image, and one of those failing
+                # says nothing about whether the amd64 package installed. Tolerate it as
+                # before and let the runnable check below decide.
+                if ! dpkg -i $PACKAGES_DIR/sysbox/sysbox-ce_*.deb; then
                   echo "Sysbox install had issues, running dpkg configure..."
                   dpkg --configure -a
-                }
-                
+                fi
+
+                if ! /usr/bin/sysbox-runc --version >/dev/null 2>&1; then
+                  echo "ERROR: sysbox-runc is not runnable after install"
+                  return 1
+                fi
+
                 echo "Sysbox installation completed"
                 return 0
               }
@@ -357,82 +370,93 @@ spec:
               
               # Function to install Sysbox (online mode)
               install_sysbox() {
+                # Pinned upstream release, verified by the sha256 published with it.
+                # Bumping these three lines is the whole version change.
+                SYSBOX_VERSION="v0.7.1"
+                SYSBOX_DEB="sysbox-ce_0.7.1.linux_amd64.deb"
+                SYSBOX_SHA256="9d6d5484f980d0a17f86c492c1262015c2afb66280bdb97215b79fde6a0261c5"
+
                 if command -v sysbox >/dev/null 2>&1 || [ -f /usr/bin/sysbox-runc ]; then
-                  echo "Sysbox is already installed"
+                  # Nodes keep the Sysbox they were provisioned with. Upgrading in place
+                  # means stopping dockerd, which kills every sandbox on the node; the pin
+                  # is picked up by replacing nodes, not by re-running this.
+                  echo "Sysbox is already installed (chart pins ${SYSBOX_VERSION}); leaving it alone"
+                  /usr/bin/sysbox-runc --version 2>/dev/null || true
                   return 0
                 fi
-                
-                echo "Installing Sysbox from GitHub releases..."
-                
+
+                echo "Installing Sysbox ${SYSBOX_VERSION} from GitHub releases..."
+
                 if command -v apt-get >/dev/null 2>&1; then
                   # Debian/Ubuntu based - install from GitHub
                   . /etc/os-release
-                  
-                  # Determine architecture
+
+                  # This chart installs the amd64 package only.
                   ARCH=$(uname -m)
                   if [ "$ARCH" != "x86_64" ] && [ "$ARCH" != "amd64" ]; then
-                    echo "Sysbox only supports x86_64 architecture"
+                    echo "ERROR: this chart installs the amd64 Sysbox package only; node is ${ARCH}"
                     return 1
                   fi
-                  
-                  # Download latest Sysbox release
-                  SYSBOX_VERSION="v0.6.4"
-                  echo "Downloading Sysbox ${SYSBOX_VERSION}..."
-                  
-                  cd /tmp
-                  
-                  # Download the deb package
-                  if curl -fsSLO "https://github.com/nestybox/sysbox/releases/download/${SYSBOX_VERSION}/sysbox-ce_0.6.4-0.linux_amd64.deb"; then
-                    echo "Downloaded Sysbox package successfully"
-                  else
-                    echo "Failed to download Sysbox, trying alternative download..."
-                    # Try without SSL verification as fallback
-                    curl -kLO "https://github.com/nestybox/sysbox/releases/download/${SYSBOX_VERSION}/sysbox-ce_0.6.4-0.linux_amd64.deb" || {
-                      echo "Failed to download Sysbox"
-                      return 1
-                    }
+
+                  cd /tmp || return 1
+                  rm -f "$SYSBOX_DEB" /tmp/sysbox.sha256
+
+                  # Download over TLS. There is deliberately no unverified retry here:
+                  # whatever lands in this file becomes the node's container runtime.
+                  echo "Downloading ${SYSBOX_DEB}..."
+                  if ! curl -fsSLO "https://github.com/nestybox/sysbox/releases/download/${SYSBOX_VERSION}/${SYSBOX_DEB}"; then
+                    echo "ERROR: failed to download ${SYSBOX_DEB}"
+                    return 1
                   fi
-                  
+
+                  echo "${SYSBOX_SHA256}  ${SYSBOX_DEB}" > /tmp/sysbox.sha256
+                  if ! sha256sum -c /tmp/sysbox.sha256; then
+                    echo "ERROR: ${SYSBOX_DEB} failed sha256 verification; refusing to install"
+                    rm -f "$SYSBOX_DEB" /tmp/sysbox.sha256
+                    return 1
+                  fi
+                  rm -f /tmp/sysbox.sha256
+
                   # Stop Docker before installing Sysbox
                   echo "Stopping Docker for Sysbox installation..."
                   systemctl stop docker 2>/dev/null || true
-                  
+
                   # Install dependencies
                   apt-get update
                   apt-get install -y jq fuse rsync rclone
-                  
+
                   # Install Sysbox
                   echo "Installing Sysbox package..."
-                  dpkg -i sysbox-ce_0.6.4-0.linux_amd64.deb || {
-                    echo "Installing Sysbox dependencies..."
+                  if ! dpkg -i "$SYSBOX_DEB"; then
+                    echo "Resolving Sysbox dependencies..."
                     apt-get install -f -y
-                    dpkg -i sysbox-ce_0.6.4-0.linux_amd64.deb
-                  }
-                  
+                    if ! dpkg -i "$SYSBOX_DEB"; then
+                      echo "ERROR: dpkg -i ${SYSBOX_DEB} failed"
+                      rm -f "$SYSBOX_DEB"
+                      return 1
+                    fi
+                  fi
+
                   # Cleanup
-                  rm -f sysbox-ce_0.6.4-0.linux_amd64.deb
-                  
-                elif command -v yum >/dev/null 2>&1; then
-                  # RHEL/CentOS based - install from GitHub
-                  SYSBOX_VERSION="v0.6.4"
-                  echo "Downloading Sysbox ${SYSBOX_VERSION} for RPM..."
-                  
-                  cd /tmp
-                  curl -fsSLO "https://github.com/nestybox/sysbox/releases/download/${SYSBOX_VERSION}/sysbox-ce-0.6.4-0.linux_amd64-rpm.tar.gz"
-                  
-                  tar -xzf sysbox-ce-0.6.4-0.linux_amd64-rpm.tar.gz
-                  
-                  # Stop Docker before installing Sysbox
-                  systemctl stop docker 2>/dev/null || true
-                  
-                  # Install Sysbox
-                  yum install -y ./sysbox-ce/*.rpm
-                  
-                  # Cleanup
-                  rm -rf sysbox-ce-0.6.4-0.linux_amd64-rpm.tar.gz sysbox-ce/
+                  rm -f "$SYSBOX_DEB"
+
+                else
+                  # Upstream publishes .deb only. The RPM tarball this chart used to fetch
+                  # has never existed as a release asset, so the yum path could only ever
+                  # 404 and then leave dockerd pointed at a runtime that was not installed.
+                  echo "ERROR: Sysbox upstream publishes .deb packages only; this node has no apt-get."
+                  echo "       Sandbox nodes must run Ubuntu 24.04 (noble) -- the same requirement the"
+                  echo "       Docker install below has. Either use an Ubuntu 24.04 node image, or"
+                  echo "       pre-install Sysbox and set services.runner.dockerInstaller.enabled=false."
+                  return 1
                 fi
-                
-                echo "Sysbox installation completed"
+
+                if ! /usr/bin/sysbox-runc --version >/dev/null 2>&1; then
+                  echo "ERROR: sysbox-runc is not runnable after install"
+                  return 1
+                fi
+
+                echo "Sysbox ${SYSBOX_VERSION} installation completed"
                 return 0
               }
               {{- end }}
@@ -592,8 +616,16 @@ spec:
               {{- end }}
               
               # Install Sysbox (before Docker, as Docker config depends on sysbox)
-              install_sysbox
-              
+              #
+              # FAIL CLOSED. configure_docker_sysbox is about to set sysbox-runc as the
+              # daemon's default runtime. If the install did not succeed, dockerd would come
+              # up pointed at a runtime that is not on the node. Distinct exit code so the
+              # outer shell can tell this apart from the peer-denial failure (3).
+              if ! install_sysbox; then
+                echo "FATAL: Sysbox installation failed; refusing to configure Docker for a runtime that is not installed"
+                exit 4
+              fi
+
               # Install Docker
               install_docker
               
@@ -795,6 +827,13 @@ spec:
               
               EOF
               bootstrap_rc=$?
+              # Propagate the Sysbox install failure out of nsenter. Without this the inner
+              # exit is swallowed and the sidecar drops into its monitor loop on a node whose
+              # Docker daemon is configured for a runtime that was never installed.
+              if [ "$bootstrap_rc" = 4 ]; then
+                echo "FATAL: host bootstrap could not install Sysbox; exiting"
+                exit 1
+              fi
 {{- if .Values.services.runner.sandboxIsolation.enabled }}
               # Propagate the peer-denial failure out of nsenter. Without this the inner
               # exit is swallowed and the container proceeds as though the node were

--- a/charts/daytona-region/templates/runner-daemonset.yaml
+++ b/charts/daytona-region/templates/runner-daemonset.yaml
@@ -253,12 +253,21 @@ spec:
               
               # Function to install Sysbox from offline packages
               install_sysbox() {
-                if command -v sysbox >/dev/null 2>&1 || [ -f /usr/bin/sysbox-runc ]; then
+                # /usr/bin/sysbox-runc is the exact path configure_docker_sysbox writes into
+                # daemon.json as the default runtime, so it is the only thing worth detecting.
+                # The package ships sysbox-fs, sysbox-mgr and sysbox-runc -- there is no plain
+                # "sysbox" binary for command -v to find, only a sysbox.service unit.
+                if [ -f /usr/bin/sysbox-runc ]; then
+                  # The file existing is not enough: a partial or corrupt install would
+                  # otherwise be reported as healthy and Docker configured against it.
+                  if ! /usr/bin/sysbox-runc --version; then
+                    echo "ERROR: /usr/bin/sysbox-runc is present but not runnable; refusing to treat this node as installed"
+                    return 1
+                  fi
                   # Nodes keep the Sysbox they were provisioned with. Upgrading in place
                   # means stopping dockerd, which kills every sandbox on the node; version
                   # changes are picked up by replacing nodes, not by re-running this.
                   echo "Sysbox is already installed; leaving it alone"
-                  /usr/bin/sysbox-runc --version 2>/dev/null || true
                   return 0
                 fi
 
@@ -376,12 +385,21 @@ spec:
                 SYSBOX_DEB="sysbox-ce_0.7.1.linux_amd64.deb"
                 SYSBOX_SHA256="9d6d5484f980d0a17f86c492c1262015c2afb66280bdb97215b79fde6a0261c5"
 
-                if command -v sysbox >/dev/null 2>&1 || [ -f /usr/bin/sysbox-runc ]; then
+                # /usr/bin/sysbox-runc is the exact path configure_docker_sysbox writes into
+                # daemon.json as the default runtime, so it is the only thing worth detecting.
+                # The package ships sysbox-fs, sysbox-mgr and sysbox-runc -- there is no plain
+                # "sysbox" binary for command -v to find, only a sysbox.service unit.
+                if [ -f /usr/bin/sysbox-runc ]; then
+                  # The file existing is not enough: a partial or corrupt install would
+                  # otherwise be reported as healthy and Docker configured against it.
+                  if ! /usr/bin/sysbox-runc --version; then
+                    echo "ERROR: /usr/bin/sysbox-runc is present but not runnable; refusing to treat this node as installed"
+                    return 1
+                  fi
                   # Nodes keep the Sysbox they were provisioned with. Upgrading in place
                   # means stopping dockerd, which kills every sandbox on the node; the pin
                   # is picked up by replacing nodes, not by re-running this.
                   echo "Sysbox is already installed (chart pins ${SYSBOX_VERSION}); leaving it alone"
-                  /usr/bin/sysbox-runc --version 2>/dev/null || true
                   return 0
                 fi
 

--- a/charts/daytona-region/tests/baselines/rendered-baseline.yaml
+++ b/charts/daytona-region/tests/baselines/rendered-baseline.yaml
@@ -6,7 +6,7 @@ metadata:
   name: release-name-daytona-region-proxy
   namespace: default
   labels:
-    helm.sh/chart: daytona-region-0.2.3
+    helm.sh/chart: daytona-region-0.2.4
     app.kubernetes.io/name: daytona-region
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "v0.207.0"
@@ -21,7 +21,7 @@ metadata:
   name: release-name-daytona-region-runnermanager
   namespace: default
   labels:
-    helm.sh/chart: daytona-region-0.2.3
+    helm.sh/chart: daytona-region-0.2.4
     app.kubernetes.io/name: daytona-region
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "v0.207.0"
@@ -36,7 +36,7 @@ metadata:
   name: release-name-daytona-region-runner
   namespace: default
   labels:
-    helm.sh/chart: daytona-region-0.2.3
+    helm.sh/chart: daytona-region-0.2.4
     app.kubernetes.io/name: daytona-region
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "v0.207.0"
@@ -51,7 +51,7 @@ metadata:
   name: release-name-daytona-region-ssh-gateway
   namespace: default
   labels:
-    helm.sh/chart: daytona-region-0.2.3
+    helm.sh/chart: daytona-region-0.2.4
     app.kubernetes.io/name: daytona-region
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "v0.207.0"
@@ -66,7 +66,7 @@ metadata:
   name: release-name-daytona-region-runner-secrets
   namespace: default
   labels:
-    helm.sh/chart: daytona-region-0.2.3
+    helm.sh/chart: daytona-region-0.2.4
     app.kubernetes.io/name: daytona-region
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "v0.207.0"
@@ -92,7 +92,7 @@ metadata:
   name: release-name-daytona-region-secret-ssh
   namespace: default
   labels:
-    helm.sh/chart: daytona-region-0.2.3
+    helm.sh/chart: daytona-region-0.2.4
     app.kubernetes.io/name: daytona-region
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "v0.207.0"
@@ -112,7 +112,7 @@ metadata:
   name: release-name-daytona-region-runner-config
   namespace: default
   labels:
-    helm.sh/chart: daytona-region-0.2.3
+    helm.sh/chart: daytona-region-0.2.4
     app.kubernetes.io/name: daytona-region
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "v0.207.0"
@@ -146,7 +146,7 @@ metadata:
   name: release-name-daytona-region-runner-docker-installer-config
   namespace: default
   labels:
-    helm.sh/chart: daytona-region-0.2.3
+    helm.sh/chart: daytona-region-0.2.4
     app.kubernetes.io/name: daytona-region
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "v0.207.0"
@@ -163,7 +163,7 @@ kind: ClusterRole
 metadata:
   name: release-name-daytona-region-runner-manager-nodes
   labels:
-    helm.sh/chart: daytona-region-0.2.3
+    helm.sh/chart: daytona-region-0.2.4
     app.kubernetes.io/name: daytona-region
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "v0.207.0"
@@ -181,7 +181,7 @@ kind: ClusterRoleBinding
 metadata:
   name: release-name-daytona-region-runner-manager-nodes
   labels:
-    helm.sh/chart: daytona-region-0.2.3
+    helm.sh/chart: daytona-region-0.2.4
     app.kubernetes.io/name: daytona-region
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "v0.207.0"
@@ -204,7 +204,7 @@ metadata:
   name: release-name-daytona-region-runnermanager
   namespace: default
   labels:
-    helm.sh/chart: daytona-region-0.2.3
+    helm.sh/chart: daytona-region-0.2.4
     app.kubernetes.io/name: daytona-region
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "v0.207.0"
@@ -229,7 +229,7 @@ metadata:
   name: release-name-daytona-region-runnermanager
   namespace: default
   labels:
-    helm.sh/chart: daytona-region-0.2.3
+    helm.sh/chart: daytona-region-0.2.4
     app.kubernetes.io/name: daytona-region
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "v0.207.0"
@@ -252,7 +252,7 @@ metadata:
   namespace: default
   name: release-name-daytona-region-proxy
   labels:
-    helm.sh/chart: daytona-region-0.2.3
+    helm.sh/chart: daytona-region-0.2.4
     app.kubernetes.io/name: daytona-region
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "v0.207.0"
@@ -278,7 +278,7 @@ metadata:
   name: release-name-daytona-region-runnermanager
   namespace: default
   labels:
-    helm.sh/chart: daytona-region-0.2.3
+    helm.sh/chart: daytona-region-0.2.4
     app.kubernetes.io/name: daytona-region
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "v0.207.0"
@@ -304,7 +304,7 @@ metadata:
   name: release-name-daytona-region-ssh-gateway
   namespace: default
   labels:
-    helm.sh/chart: daytona-region-0.2.3
+    helm.sh/chart: daytona-region-0.2.4
     app.kubernetes.io/name: daytona-region
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "v0.207.0"
@@ -330,7 +330,7 @@ metadata:
   name: release-name-daytona-region-runner
   namespace: default
   labels:
-    helm.sh/chart: daytona-region-0.2.3
+    helm.sh/chart: daytona-region-0.2.4
     app.kubernetes.io/name: daytona-region
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "v0.207.0"
@@ -501,82 +501,93 @@ spec:
               
               # Function to install Sysbox (online mode)
               install_sysbox() {
+                # Pinned upstream release, verified by the sha256 published with it.
+                # Bumping these three lines is the whole version change.
+                SYSBOX_VERSION="v0.7.1"
+                SYSBOX_DEB="sysbox-ce_0.7.1.linux_amd64.deb"
+                SYSBOX_SHA256="9d6d5484f980d0a17f86c492c1262015c2afb66280bdb97215b79fde6a0261c5"
+
                 if command -v sysbox >/dev/null 2>&1 || [ -f /usr/bin/sysbox-runc ]; then
-                  echo "Sysbox is already installed"
+                  # Nodes keep the Sysbox they were provisioned with. Upgrading in place
+                  # means stopping dockerd, which kills every sandbox on the node; the pin
+                  # is picked up by replacing nodes, not by re-running this.
+                  echo "Sysbox is already installed (chart pins ${SYSBOX_VERSION}); leaving it alone"
+                  /usr/bin/sysbox-runc --version 2>/dev/null || true
                   return 0
                 fi
-                
-                echo "Installing Sysbox from GitHub releases..."
-                
+
+                echo "Installing Sysbox ${SYSBOX_VERSION} from GitHub releases..."
+
                 if command -v apt-get >/dev/null 2>&1; then
                   # Debian/Ubuntu based - install from GitHub
                   . /etc/os-release
-                  
-                  # Determine architecture
+
+                  # This chart installs the amd64 package only.
                   ARCH=$(uname -m)
                   if [ "$ARCH" != "x86_64" ] && [ "$ARCH" != "amd64" ]; then
-                    echo "Sysbox only supports x86_64 architecture"
+                    echo "ERROR: this chart installs the amd64 Sysbox package only; node is ${ARCH}"
                     return 1
                   fi
-                  
-                  # Download latest Sysbox release
-                  SYSBOX_VERSION="v0.6.4"
-                  echo "Downloading Sysbox ${SYSBOX_VERSION}..."
-                  
-                  cd /tmp
-                  
-                  # Download the deb package
-                  if curl -fsSLO "https://github.com/nestybox/sysbox/releases/download/${SYSBOX_VERSION}/sysbox-ce_0.6.4-0.linux_amd64.deb"; then
-                    echo "Downloaded Sysbox package successfully"
-                  else
-                    echo "Failed to download Sysbox, trying alternative download..."
-                    # Try without SSL verification as fallback
-                    curl -kLO "https://github.com/nestybox/sysbox/releases/download/${SYSBOX_VERSION}/sysbox-ce_0.6.4-0.linux_amd64.deb" || {
-                      echo "Failed to download Sysbox"
-                      return 1
-                    }
+
+                  cd /tmp || return 1
+                  rm -f "$SYSBOX_DEB" /tmp/sysbox.sha256
+
+                  # Download over TLS. There is deliberately no unverified retry here:
+                  # whatever lands in this file becomes the node's container runtime.
+                  echo "Downloading ${SYSBOX_DEB}..."
+                  if ! curl -fsSLO "https://github.com/nestybox/sysbox/releases/download/${SYSBOX_VERSION}/${SYSBOX_DEB}"; then
+                    echo "ERROR: failed to download ${SYSBOX_DEB}"
+                    return 1
                   fi
-                  
+
+                  echo "${SYSBOX_SHA256}  ${SYSBOX_DEB}" > /tmp/sysbox.sha256
+                  if ! sha256sum -c /tmp/sysbox.sha256; then
+                    echo "ERROR: ${SYSBOX_DEB} failed sha256 verification; refusing to install"
+                    rm -f "$SYSBOX_DEB" /tmp/sysbox.sha256
+                    return 1
+                  fi
+                  rm -f /tmp/sysbox.sha256
+
                   # Stop Docker before installing Sysbox
                   echo "Stopping Docker for Sysbox installation..."
                   systemctl stop docker 2>/dev/null || true
-                  
+
                   # Install dependencies
                   apt-get update
                   apt-get install -y jq fuse rsync rclone
-                  
+
                   # Install Sysbox
                   echo "Installing Sysbox package..."
-                  dpkg -i sysbox-ce_0.6.4-0.linux_amd64.deb || {
-                    echo "Installing Sysbox dependencies..."
+                  if ! dpkg -i "$SYSBOX_DEB"; then
+                    echo "Resolving Sysbox dependencies..."
                     apt-get install -f -y
-                    dpkg -i sysbox-ce_0.6.4-0.linux_amd64.deb
-                  }
-                  
+                    if ! dpkg -i "$SYSBOX_DEB"; then
+                      echo "ERROR: dpkg -i ${SYSBOX_DEB} failed"
+                      rm -f "$SYSBOX_DEB"
+                      return 1
+                    fi
+                  fi
+
                   # Cleanup
-                  rm -f sysbox-ce_0.6.4-0.linux_amd64.deb
-                  
-                elif command -v yum >/dev/null 2>&1; then
-                  # RHEL/CentOS based - install from GitHub
-                  SYSBOX_VERSION="v0.6.4"
-                  echo "Downloading Sysbox ${SYSBOX_VERSION} for RPM..."
-                  
-                  cd /tmp
-                  curl -fsSLO "https://github.com/nestybox/sysbox/releases/download/${SYSBOX_VERSION}/sysbox-ce-0.6.4-0.linux_amd64-rpm.tar.gz"
-                  
-                  tar -xzf sysbox-ce-0.6.4-0.linux_amd64-rpm.tar.gz
-                  
-                  # Stop Docker before installing Sysbox
-                  systemctl stop docker 2>/dev/null || true
-                  
-                  # Install Sysbox
-                  yum install -y ./sysbox-ce/*.rpm
-                  
-                  # Cleanup
-                  rm -rf sysbox-ce-0.6.4-0.linux_amd64-rpm.tar.gz sysbox-ce/
+                  rm -f "$SYSBOX_DEB"
+
+                else
+                  # Upstream publishes .deb only. The RPM tarball this chart used to fetch
+                  # has never existed as a release asset, so the yum path could only ever
+                  # 404 and then leave dockerd pointed at a runtime that was not installed.
+                  echo "ERROR: Sysbox upstream publishes .deb packages only; this node has no apt-get."
+                  echo "       Sandbox nodes must run Ubuntu 24.04 (noble) -- the same requirement the"
+                  echo "       Docker install below has. Either use an Ubuntu 24.04 node image, or"
+                  echo "       pre-install Sysbox and set services.runner.dockerInstaller.enabled=false."
+                  return 1
                 fi
-                
-                echo "Sysbox installation completed"
+
+                if ! /usr/bin/sysbox-runc --version >/dev/null 2>&1; then
+                  echo "ERROR: sysbox-runc is not runnable after install"
+                  return 1
+                fi
+
+                echo "Sysbox ${SYSBOX_VERSION} installation completed"
                 return 0
               }
               
@@ -720,8 +731,16 @@ spec:
               setup_xfs_storage
               
               # Install Sysbox (before Docker, as Docker config depends on sysbox)
-              install_sysbox
-              
+              #
+              # FAIL CLOSED. configure_docker_sysbox is about to set sysbox-runc as the
+              # daemon's default runtime. If the install did not succeed, dockerd would come
+              # up pointed at a runtime that is not on the node. Distinct exit code so the
+              # outer shell can tell this apart from the peer-denial failure (3).
+              if ! install_sysbox; then
+                echo "FATAL: Sysbox installation failed; refusing to configure Docker for a runtime that is not installed"
+                exit 4
+              fi
+
               # Install Docker
               install_docker
               
@@ -887,6 +906,13 @@ spec:
               
               EOF
               bootstrap_rc=$?
+              # Propagate the Sysbox install failure out of nsenter. Without this the inner
+              # exit is swallowed and the sidecar drops into its monitor loop on a node whose
+              # Docker daemon is configured for a runtime that was never installed.
+              if [ "$bootstrap_rc" = 4 ]; then
+                echo "FATAL: host bootstrap could not install Sysbox; exiting"
+                exit 1
+              fi
               # Propagate the peer-denial failure out of nsenter. Without this the inner
               # exit is swallowed and the container proceeds as though the node were
               # protected.
@@ -1104,7 +1130,7 @@ metadata:
   namespace: default
   name: release-name-daytona-region-proxy
   labels:
-    helm.sh/chart: daytona-region-0.2.3
+    helm.sh/chart: daytona-region-0.2.4
     app.kubernetes.io/name: daytona-region
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "v0.207.0"
@@ -1179,7 +1205,7 @@ metadata:
   namespace: default
   name: release-name-daytona-region-runnermanager
   labels:
-    helm.sh/chart: daytona-region-0.2.3
+    helm.sh/chart: daytona-region-0.2.4
     app.kubernetes.io/name: daytona-region
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "v0.207.0"
@@ -1298,7 +1324,7 @@ metadata:
   name: release-name-daytona-region-ssh-gateway
   namespace: default
   labels:
-    helm.sh/chart: daytona-region-0.2.3
+    helm.sh/chart: daytona-region-0.2.4
     app.kubernetes.io/name: daytona-region
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "v0.207.0"
@@ -1362,7 +1388,7 @@ metadata:
   name: release-name-daytona-region-proxy
   namespace: default
   labels:
-    helm.sh/chart: daytona-region-0.2.3
+    helm.sh/chart: daytona-region-0.2.4
     app.kubernetes.io/name: daytona-region
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "v0.207.0"
@@ -1409,7 +1435,7 @@ metadata:
   name: release-name-daytona-region-region-registration
   namespace: default
   labels:
-    helm.sh/chart: daytona-region-0.2.3
+    helm.sh/chart: daytona-region-0.2.4
     app.kubernetes.io/name: daytona-region
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "v0.207.0"
@@ -1428,7 +1454,7 @@ metadata:
   name: release-name-daytona-region-daytona-api-key
   namespace: default
   labels:
-    helm.sh/chart: daytona-region-0.2.3
+    helm.sh/chart: daytona-region-0.2.4
     app.kubernetes.io/name: daytona-region
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "v0.207.0"
@@ -1452,7 +1478,7 @@ metadata:
   name: release-name-daytona-region-region-registration
   namespace: default
   labels:
-    helm.sh/chart: daytona-region-0.2.3
+    helm.sh/chart: daytona-region-0.2.4
     app.kubernetes.io/name: daytona-region
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "v0.207.0"
@@ -1475,7 +1501,7 @@ metadata:
   name: release-name-daytona-region-region-registration
   namespace: default
   labels:
-    helm.sh/chart: daytona-region-0.2.3
+    helm.sh/chart: daytona-region-0.2.4
     app.kubernetes.io/name: daytona-region
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "v0.207.0"
@@ -1502,7 +1528,7 @@ metadata:
   name: release-name-daytona-region-region-registration
   namespace: default
   labels:
-    helm.sh/chart: daytona-region-0.2.3
+    helm.sh/chart: daytona-region-0.2.4
     app.kubernetes.io/name: daytona-region
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "v0.207.0"
@@ -1551,7 +1577,7 @@ spec:
                 name: release-name-daytona-region-region-config
                 namespace: default
                 labels:
-                  helm.sh/chart: daytona-region-0.2.3
+                  helm.sh/chart: daytona-region-0.2.4
                   app.kubernetes.io/name: daytona-region
                   app.kubernetes.io/instance: release-name
                   app.kubernetes.io/version: "v0.207.0"

--- a/charts/daytona-region/tests/baselines/rendered-baseline.yaml
+++ b/charts/daytona-region/tests/baselines/rendered-baseline.yaml
@@ -507,12 +507,21 @@ spec:
                 SYSBOX_DEB="sysbox-ce_0.7.1.linux_amd64.deb"
                 SYSBOX_SHA256="9d6d5484f980d0a17f86c492c1262015c2afb66280bdb97215b79fde6a0261c5"
 
-                if command -v sysbox >/dev/null 2>&1 || [ -f /usr/bin/sysbox-runc ]; then
+                # /usr/bin/sysbox-runc is the exact path configure_docker_sysbox writes into
+                # daemon.json as the default runtime, so it is the only thing worth detecting.
+                # The package ships sysbox-fs, sysbox-mgr and sysbox-runc -- there is no plain
+                # "sysbox" binary for command -v to find, only a sysbox.service unit.
+                if [ -f /usr/bin/sysbox-runc ]; then
+                  # The file existing is not enough: a partial or corrupt install would
+                  # otherwise be reported as healthy and Docker configured against it.
+                  if ! /usr/bin/sysbox-runc --version; then
+                    echo "ERROR: /usr/bin/sysbox-runc is present but not runnable; refusing to treat this node as installed"
+                    return 1
+                  fi
                   # Nodes keep the Sysbox they were provisioned with. Upgrading in place
                   # means stopping dockerd, which kills every sandbox on the node; the pin
                   # is picked up by replacing nodes, not by re-running this.
                   echo "Sysbox is already installed (chart pins ${SYSBOX_VERSION}); leaving it alone"
-                  /usr/bin/sysbox-runc --version 2>/dev/null || true
                   return 0
                 fi
 


### PR DESCRIPTION
The chart installed Sysbox v0.6.4. Upstream v0.7.0 ported the runc security patches for CVE-2025-3133, CVE-2025-52881 and CVE-2025-52565, and added Ubuntu 24.04 / kernel 6.8+ support under containerd 2.x.

Ten version literals collapse into three variables at the top of `install_sysbox`, so the next bump is a three-line change. Package dependencies are identical between 0.6.4 and 0.7.1 (`jq`, `fuse`, `lsb-release`, `rsync`, `iptables`) — nothing new to install.

### Alongside the bump

**Digest verification.** The `.deb` is checked against the sha256 published with the release before `dpkg -i`. Digest confirmed against the release API, the release notes, and the artifact itself.

**`curl -kLO` removed.** The retry disabled TLS verification on the download that becomes the node's container runtime. This is the one behaviour change reachable on a fresh node: an install behind a TLS-intercepting proxy that relied on the fallback should trust the proxy CA on the node image, or pre-install Sysbox and set `services.runner.dockerInstaller.enabled=false`.

**yum branch removed.** It fetched `sysbox-ce-<ver>-...-rpm.tar.gz`, which has never existed as a release asset — upstream publishes `.deb` only, for every tag. With no `set -e`, the 404 fell through to `echo "Sysbox installation completed"; return 0`, and the failure surfaced later as a confusing dockerd error. It now reports the Ubuntu 24.04 (noble) requirement the Docker install already has, and fails.

**Existing installs are validated, not assumed.** The already-installed early return probed `sysbox-runc` with `|| true` and returned success regardless, so a partial or corrupt install was reported as healthy and Docker configured against it. The probe is now authoritative. The `command -v sysbox` half of the detector is gone: the package ships `sysbox-fs`, `sysbox-mgr` and `sysbox-runc` plus a `sysbox.service` unit, so there is no plain `sysbox` executable for it to match, and anything else on PATH by that name would have suppressed the install without providing the runtime.

**Install failure now fails closed.** `install_sysbox` was called with its return value discarded, so a failure fell through to `configure_docker_sysbox` writing `sysbox-runc` as the daemon's default runtime for a binary that was not on the node. Exit code 4, propagated out of `nsenter` alongside the peer-denial path's code 3.

### Upgrade behaviour

Nodes with a healthy Sysbox keep the version they were provisioned with. An in-place upgrade means stopping dockerd, which stops every sandbox on that node. The early return is unchanged — it now logs the installed version so drift from the pin is visible. **The new pin arrives by replacing nodes.**

The airgapped path keeps tolerating a non-zero `dpkg` status: the package glob can match more than one architecture, and a failure on one says nothing about the other. Both paths gate on `sysbox-runc` being runnable after the install instead.

`services.runner.dockerInstaller.airgapped.packagesImage` ships its own Sysbox copy and is built outside this repo — bumping it is a separate change.

### Verification

- `helm template` × 4 value permutations (online/airgapped × isolation on/off); chart lints; baseline regenerated (pre-regeneration diff was entirely this change); values-template and no-install-sh gates pass.
- `sh -n` and `bash -n` over all 11 rendered scripts, including the 383–478 line `nsenter` heredoc bodies.
- 22 assertions on the rendered output; 11 behavioural cases running the rendered `install_sysbox` against stubbed binaries, both paths, under `sh` and `bash`:
  - healthy existing install → returns 0, **dockerd is never stopped**
  - **broken existing install** (binary present, will not execute) → returns 1, dockerd never stopped
  - stray `sysbox` on PATH with no `/usr/bin/sysbox-runc` → installs, rather than short-circuiting
  - download failure, digest mismatch, non-apt host, dpkg failure with no runtime → all return 1
  - airgapped multi-arch glob (dpkg non-zero, `sysbox-runc` present) → returns 0
- `sha256sum -c` exercised against the real artifact: passes on the published digest, fails on a one-character change.

`helm unittest` reports 2 pre-existing failures in `runner-sandbox-hardening_test.yaml` (stale `iptables -w` regexes from #39). Identical on `main`; fixed separately.

