### PR TITLE
fix(daytona-region): bound the ip6tables wait in the peer-denial script

### DIFF
--- a/charts/daytona-region/Chart.yaml
+++ b/charts/daytona-region/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: daytona-region
 description: A Helm chart for Daytona custom region
 type: application
-version: 0.2.4
+version: 0.2.5
 appVersion: "v0.207.0"
 keywords:
   - ai

--- a/charts/daytona-region/templates/runner-daemonset.yaml
+++ b/charts/daytona-region/templates/runner-daemonset.yaml
@@ -735,8 +735,8 @@ spec:
               # chain exists on every node this chart provisions and a failure here is a real
               # gap, not an absent feature: containers can hold IPv6 addresses and sandbox
               # services bind ::. Counts toward the exit status.
-              if ! ip6tables -w -C DOCKER-USER -i docker0 -o docker0 -j DROP 2>/dev/null; then
-                if ip6tables -w -I DOCKER-USER 1 -i docker0 -o docker0 -j DROP; then
+              if ! ip6tables -w 5 -C DOCKER-USER -i docker0 -o docker0 -j DROP 2>/dev/null; then
+                if ip6tables -w 5 -I DOCKER-USER 1 -i docker0 -o docker0 -j DROP; then
                   echo "Installed IPv6 sandbox peer-denial rule"
                   changed=1
                 else
@@ -766,8 +766,8 @@ spec:
               while iptables -w 5 -C DOCKER-USER -i docker0 -o docker0 -j DROP 2>/dev/null; do
                 iptables -w 5 -D DOCKER-USER -i docker0 -o docker0 -j DROP || break
               done
-              while ip6tables -w -C DOCKER-USER -i docker0 -o docker0 -j DROP 2>/dev/null; do
-                ip6tables -w -D DOCKER-USER -i docker0 -o docker0 -j DROP || break
+              while ip6tables -w 5 -C DOCKER-USER -i docker0 -o docker0 -j DROP 2>/dev/null; do
+                ip6tables -w 5 -D DOCKER-USER -i docker0 -o docker0 -j DROP || break
               done
 {{- end }}
 

--- a/charts/daytona-region/tests/baselines/rendered-baseline.yaml
+++ b/charts/daytona-region/tests/baselines/rendered-baseline.yaml
@@ -6,7 +6,7 @@ metadata:
   name: release-name-daytona-region-proxy
   namespace: default
   labels:
-    helm.sh/chart: daytona-region-0.2.4
+    helm.sh/chart: daytona-region-0.2.5
     app.kubernetes.io/name: daytona-region
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "v0.207.0"
@@ -21,7 +21,7 @@ metadata:
   name: release-name-daytona-region-runnermanager
   namespace: default
   labels:
-    helm.sh/chart: daytona-region-0.2.4
+    helm.sh/chart: daytona-region-0.2.5
     app.kubernetes.io/name: daytona-region
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "v0.207.0"
@@ -36,7 +36,7 @@ metadata:
   name: release-name-daytona-region-runner
   namespace: default
   labels:
-    helm.sh/chart: daytona-region-0.2.4
+    helm.sh/chart: daytona-region-0.2.5
     app.kubernetes.io/name: daytona-region
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "v0.207.0"
@@ -51,7 +51,7 @@ metadata:
   name: release-name-daytona-region-ssh-gateway
   namespace: default
   labels:
-    helm.sh/chart: daytona-region-0.2.4
+    helm.sh/chart: daytona-region-0.2.5
     app.kubernetes.io/name: daytona-region
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "v0.207.0"
@@ -66,7 +66,7 @@ metadata:
   name: release-name-daytona-region-runner-secrets
   namespace: default
   labels:
-    helm.sh/chart: daytona-region-0.2.4
+    helm.sh/chart: daytona-region-0.2.5
     app.kubernetes.io/name: daytona-region
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "v0.207.0"
@@ -92,7 +92,7 @@ metadata:
   name: release-name-daytona-region-secret-ssh
   namespace: default
   labels:
-    helm.sh/chart: daytona-region-0.2.4
+    helm.sh/chart: daytona-region-0.2.5
     app.kubernetes.io/name: daytona-region
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "v0.207.0"
@@ -112,7 +112,7 @@ metadata:
   name: release-name-daytona-region-runner-config
   namespace: default
   labels:
-    helm.sh/chart: daytona-region-0.2.4
+    helm.sh/chart: daytona-region-0.2.5
     app.kubernetes.io/name: daytona-region
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "v0.207.0"
@@ -146,7 +146,7 @@ metadata:
   name: release-name-daytona-region-runner-docker-installer-config
   namespace: default
   labels:
-    helm.sh/chart: daytona-region-0.2.4
+    helm.sh/chart: daytona-region-0.2.5
     app.kubernetes.io/name: daytona-region
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "v0.207.0"
@@ -163,7 +163,7 @@ kind: ClusterRole
 metadata:
   name: release-name-daytona-region-runner-manager-nodes
   labels:
-    helm.sh/chart: daytona-region-0.2.4
+    helm.sh/chart: daytona-region-0.2.5
     app.kubernetes.io/name: daytona-region
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "v0.207.0"
@@ -181,7 +181,7 @@ kind: ClusterRoleBinding
 metadata:
   name: release-name-daytona-region-runner-manager-nodes
   labels:
-    helm.sh/chart: daytona-region-0.2.4
+    helm.sh/chart: daytona-region-0.2.5
     app.kubernetes.io/name: daytona-region
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "v0.207.0"
@@ -204,7 +204,7 @@ metadata:
   name: release-name-daytona-region-runnermanager
   namespace: default
   labels:
-    helm.sh/chart: daytona-region-0.2.4
+    helm.sh/chart: daytona-region-0.2.5
     app.kubernetes.io/name: daytona-region
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "v0.207.0"
@@ -229,7 +229,7 @@ metadata:
   name: release-name-daytona-region-runnermanager
   namespace: default
   labels:
-    helm.sh/chart: daytona-region-0.2.4
+    helm.sh/chart: daytona-region-0.2.5
     app.kubernetes.io/name: daytona-region
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "v0.207.0"
@@ -252,7 +252,7 @@ metadata:
   namespace: default
   name: release-name-daytona-region-proxy
   labels:
-    helm.sh/chart: daytona-region-0.2.4
+    helm.sh/chart: daytona-region-0.2.5
     app.kubernetes.io/name: daytona-region
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "v0.207.0"
@@ -278,7 +278,7 @@ metadata:
   name: release-name-daytona-region-runnermanager
   namespace: default
   labels:
-    helm.sh/chart: daytona-region-0.2.4
+    helm.sh/chart: daytona-region-0.2.5
     app.kubernetes.io/name: daytona-region
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "v0.207.0"
@@ -304,7 +304,7 @@ metadata:
   name: release-name-daytona-region-ssh-gateway
   namespace: default
   labels:
-    helm.sh/chart: daytona-region-0.2.4
+    helm.sh/chart: daytona-region-0.2.5
     app.kubernetes.io/name: daytona-region
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "v0.207.0"
@@ -330,7 +330,7 @@ metadata:
   name: release-name-daytona-region-runner
   namespace: default
   labels:
-    helm.sh/chart: daytona-region-0.2.4
+    helm.sh/chart: daytona-region-0.2.5
     app.kubernetes.io/name: daytona-region
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "v0.207.0"
@@ -821,8 +821,8 @@ spec:
               # chain exists on every node this chart provisions and a failure here is a real
               # gap, not an absent feature: containers can hold IPv6 addresses and sandbox
               # services bind ::. Counts toward the exit status.
-              if ! ip6tables -w -C DOCKER-USER -i docker0 -o docker0 -j DROP 2>/dev/null; then
-                if ip6tables -w -I DOCKER-USER 1 -i docker0 -o docker0 -j DROP; then
+              if ! ip6tables -w 5 -C DOCKER-USER -i docker0 -o docker0 -j DROP 2>/dev/null; then
+                if ip6tables -w 5 -I DOCKER-USER 1 -i docker0 -o docker0 -j DROP; then
                   echo "Installed IPv6 sandbox peer-denial rule"
                   changed=1
                 else
@@ -1139,7 +1139,7 @@ metadata:
   namespace: default
   name: release-name-daytona-region-proxy
   labels:
-    helm.sh/chart: daytona-region-0.2.4
+    helm.sh/chart: daytona-region-0.2.5
     app.kubernetes.io/name: daytona-region
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "v0.207.0"
@@ -1214,7 +1214,7 @@ metadata:
   namespace: default
   name: release-name-daytona-region-runnermanager
   labels:
-    helm.sh/chart: daytona-region-0.2.4
+    helm.sh/chart: daytona-region-0.2.5
     app.kubernetes.io/name: daytona-region
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "v0.207.0"
@@ -1333,7 +1333,7 @@ metadata:
   name: release-name-daytona-region-ssh-gateway
   namespace: default
   labels:
-    helm.sh/chart: daytona-region-0.2.4
+    helm.sh/chart: daytona-region-0.2.5
     app.kubernetes.io/name: daytona-region
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "v0.207.0"
@@ -1397,7 +1397,7 @@ metadata:
   name: release-name-daytona-region-proxy
   namespace: default
   labels:
-    helm.sh/chart: daytona-region-0.2.4
+    helm.sh/chart: daytona-region-0.2.5
     app.kubernetes.io/name: daytona-region
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "v0.207.0"
@@ -1444,7 +1444,7 @@ metadata:
   name: release-name-daytona-region-region-registration
   namespace: default
   labels:
-    helm.sh/chart: daytona-region-0.2.4
+    helm.sh/chart: daytona-region-0.2.5
     app.kubernetes.io/name: daytona-region
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "v0.207.0"
@@ -1463,7 +1463,7 @@ metadata:
   name: release-name-daytona-region-daytona-api-key
   namespace: default
   labels:
-    helm.sh/chart: daytona-region-0.2.4
+    helm.sh/chart: daytona-region-0.2.5
     app.kubernetes.io/name: daytona-region
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "v0.207.0"
@@ -1487,7 +1487,7 @@ metadata:
   name: release-name-daytona-region-region-registration
   namespace: default
   labels:
-    helm.sh/chart: daytona-region-0.2.4
+    helm.sh/chart: daytona-region-0.2.5
     app.kubernetes.io/name: daytona-region
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "v0.207.0"
@@ -1510,7 +1510,7 @@ metadata:
   name: release-name-daytona-region-region-registration
   namespace: default
   labels:
-    helm.sh/chart: daytona-region-0.2.4
+    helm.sh/chart: daytona-region-0.2.5
     app.kubernetes.io/name: daytona-region
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "v0.207.0"
@@ -1537,7 +1537,7 @@ metadata:
   name: release-name-daytona-region-region-registration
   namespace: default
   labels:
-    helm.sh/chart: daytona-region-0.2.4
+    helm.sh/chart: daytona-region-0.2.5
     app.kubernetes.io/name: daytona-region
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "v0.207.0"
@@ -1586,7 +1586,7 @@ spec:
                 name: release-name-daytona-region-region-config
                 namespace: default
                 labels:
-                  helm.sh/chart: daytona-region-0.2.4
+                  helm.sh/chart: daytona-region-0.2.5
                   app.kubernetes.io/name: daytona-region
                   app.kubernetes.io/instance: release-name
                   app.kubernetes.io/version: "v0.207.0"

--- a/charts/daytona-region/tests/runner-sandbox-hardening_test.yaml
+++ b/charts/daytona-region/tests/runner-sandbox-hardening_test.yaml
@@ -56,10 +56,10 @@ tests:
       # The rule itself.
       - matchRegex:
           path: spec.template.spec.containers[0].args[0]
-          pattern: 'iptables -w -I DOCKER-USER 1 -i docker0 -o docker0 -j DROP'
+          pattern: 'iptables -w 5 -I DOCKER-USER 1 -i docker0 -o docker0 -j DROP'
       - matchRegex:
           path: spec.template.spec.containers[0].args[0]
-          pattern: 'ip6tables -w -I DOCKER-USER 1 -i docker0 -o docker0 -j DROP'
+          pattern: 'ip6tables -w 5 -I DOCKER-USER 1 -i docker0 -o docker0 -j DROP'
       # The kernel precondition, without which the rule filters nothing.
       - matchRegex:
           path: spec.template.spec.containers[0].args[0]
@@ -126,13 +126,20 @@ tests:
       # No enforcement, and no orphaned rule left behind.
       - notMatchRegex:
           path: spec.template.spec.containers[0].args[0]
-          pattern: 'iptables -w -I DOCKER-USER 1 -i docker0 -o docker0 -j DROP'
+          pattern: 'iptables -w 5 -I DOCKER-USER 1 -i docker0 -o docker0 -j DROP'
+      - notMatchRegex:
+          path: spec.template.spec.containers[0].args[0]
+          pattern: 'ip6tables -w 5 -I DOCKER-USER 1 -i docker0 -o docker0 -j DROP'
       - notMatchRegex:
           path: spec.template.spec.containers[0].args[0]
           pattern: '"icc": false'
       - matchRegex:
           path: spec.template.spec.containers[0].args[0]
-          pattern: 'iptables -w -D DOCKER-USER -i docker0 -o docker0 -j DROP'
+          pattern: 'iptables -w 5 -D DOCKER-USER -i docker0 -o docker0 -j DROP'
+      # Both families are torn down; dropping the v6 cleanup would orphan a DROP.
+      - matchRegex:
+          path: spec.template.spec.containers[0].args[0]
+          pattern: 'ip6tables -w 5 -D DOCKER-USER -i docker0 -o docker0 -j DROP'
 
   - it: networkPolicy.enabled renders the egress-enforcer with block + input rules
     set:


### PR DESCRIPTION
> Stacked on #41. Base is `chore/sysbox-0.7.1`; merge that first and this retargets to `main`.

#39 gave every `iptables` call in `daytona-peer-denial.sh` a bounded `-w 5`, so a reconcile cannot block on the xtables lock. All four `ip6tables` calls in the same script kept a bare `-w`.

Per [iptables(8)](https://ipset.netfilter.org/iptables.man.html), `-w` without a value waits **indefinitely**; the seconds argument is what bounds it. So the IPv6 half of the script could stall the bootstrap and the 60s monitor loop that the timeout was added to protect. Both the insert path (`-C`/`-I`) and the teardown path taken when `sandboxIsolation` is disabled (`-C`/`-D`) are affected.

The `ipt() { iptables -w "$@"; }` helper in the egress-enforcer is a bare `-w` too, but it predates #39 and belongs to a different function — left alone here.

### Tests

Two assertions still expected the pre-#39 `-w` form and had been failing since that PR merged:

| | expected | rendered |
|---|---|---|
| `runner-sandbox-hardening_test.yaml:59` | `iptables -w -I …` | `iptables -w 5 -I …` |
| `:135` | `iptables -w -D …` | `iptables -w 5 -D …` |

Nothing caught this because no workflow runs `helm unittest` — `.github/workflows/` contains only the `workflow_dispatch` publish job. The regexes now assert the invocation that actually renders.

The `ip6tables` assertion at `:62` passed only because it matched the unbounded form; it moves to `-w 5` with the code.

Also added: the isolation-disabled suite asserted the IPv4 rule is removed but never checked IPv6, so dropping the v6 cleanup would have orphaned a DROP with no test failing. Both families are now covered on teardown, and the v6 insert is covered by `notMatchRegex`.

### Verification

`helm unittest`: **41/41, 8/8 suites** — first fully green run. Baseline regenerated; its only semantic delta against the parent branch is the two `ip6tables` lines plus the chart version label. Chart lints; baseline-compat and values-template gates pass. All 11 rendered scripts pass `sh -n` and `bash -n` across the four value permutations, and no bare `ip6tables -w` remains in the peer-denial script in either the isolation-on or isolation-off render.
