### PR TITLE
fix(daytona-region): install fuse3 for Sysbox 0.7.1

### DIFF
--- a/charts/daytona-region/templates/runner-daemonset.yaml
+++ b/charts/daytona-region/templates/runner-daemonset.yaml
@@ -441,7 +441,7 @@ spec:
 
                   # Install dependencies
                   apt-get update
-                  apt-get install -y jq fuse rsync rclone
+                  apt-get install -y jq fuse3 rsync rclone
 
                   # Install Sysbox
                   echo "Installing Sysbox package..."


### PR DESCRIPTION
# Description

Replace the legacy fuse package with fuse3 in the chart’s online runner-host installer. Sysbox 0.7.1 invokes fusermount3, but installing fuse on Ubuntu 24.04 removes Fuse3 and leaves that executable unavailable, causing sandbox startup to fail.

This is an isolated dependency change for fresh host provisioning. It does not change Sysbox versions, existing-node upgrade behavior, XFS setup, or other chart functionality.